### PR TITLE
Hide skyweaver dev cards

### DIFF
--- a/index/polygon/erc1155.json
+++ b/index/polygon/erc1155.json
@@ -50,7 +50,8 @@
         "ogImage": "https://skyweaver.net/images/skyweavercover.jpg",
         "originChainId": 137,
         "originAddress": "0xDFd64eE208629DCb1cEF4a148c50Bb3079D449e3"
-      }
+      },
+      "blacklist": true
     },
     {
       "chainId": 137,
@@ -65,7 +66,8 @@
         "ogImage": "https://skyweaver.net/images/skyweavercover.jpg",
         "originChainId": 137,
         "originAddress": "0xC4c544D22BCc110652944BcA5Cf6330dd04D081a"
-      }
+      },
+      "blacklist": true
     },
     {
       "chainId": 137,


### PR DESCRIPTION
Looks like by using some prod data in our dev environments, we sent dev cards from leaderboard rewards to our players, who get confused as to what these dev skyweaver cards are. Adding this will prevent us from seeing these in our own wallets, but that seems fine.