### PR TITLE
rename old/bridged USDC to USDC.e

### DIFF
--- a/index/polygon/erc20.json
+++ b/index/polygon/erc20.json
@@ -656,13 +656,13 @@
     {
       "chainId": 137,
       "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
-      "name": "USDC",
-      "symbol": "USDC",
+      "name": "USDC.e",
+      "symbol": "USDC.e",
       "decimals": 6,
       "logoURI": "https://assets.coingecko.com/coins/images/6319/large/USD_Coin_icon.png?1547042389",
       "extensions": {
         "link": "https://www.circle.com/en/usdc",
-        "description": "USDC is a fully collateralized US dollar stablecoin. USDC is the bridge between dollars and trading on cryptocurrency exchanges. The technology behind CENTRE makes it possible to exchange value between people, businesses and financial institutions just like email between mail services and texts between SMS providers. We believe by removing artificial economic borders, we can create a more inclusive global economy. ",
+        "description": "USDC bridged from Ethereum network.",
         "ogImage": "https://www.circle.com/hubfs/share-USDC.png#keepProtocol",
         "originChainId": 1,
         "originAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"


### PR DESCRIPTION
as noted by https://www.circle.com/blog/native-usdc-now-available-on-polygon-pos

Polygon now has native USDC, this PR renames the old/bridged USDC to "USDC.e"

Question, for the "originAddress", should we remove this for the native USDC ..?