### PR TITLE
Added Token Categories Arrays (All Chains but mainnet)

### DIFF
--- a/index/arbitrum-nova/erc1155.json
+++ b/index/arbitrum-nova/erc1155.json
@@ -34,7 +34,7 @@
       "extensions": {
         "link": "https://0xsequence-demos.github.io/demo-lootbox/",
         "description": "A free lootbox mini-game available for use. Browse a maze and open AI generated diablo loot via http://Scenario.gg",
-        "categories": ["gaming", "ai", "rpg"],
+        "categories": ["gaming", "ai", "rpg", "fantasy"],
         "ogImage": "https://0xsequence-demos.github.io/demo-lootbox/assets/maze-95401e2d.png",
         "originChainId": 42170,
         "originAddress": "0xaf8a08bf8b2945c2779ae507dade15985ea11fbc"

--- a/index/arbitrum-nova/erc1155.json
+++ b/index/arbitrum-nova/erc1155.json
@@ -17,6 +17,7 @@
       "extensions": {
         "link": "https://sovereignty.gg/",
         "description": "Tokenized resources for Sovereignty, an interactive MMO strategy game. Build your empire, conquer the world, and become the ruler of all.",
+        "categories": ["gaming", "mmo", "strategy"],
         "ogImage": "",
         "originChainId": 42170,
         "originAddress": ""
@@ -33,6 +34,7 @@
       "extensions": {
         "link": "https://0xsequence-demos.github.io/demo-lootbox/",
         "description": "A free lootbox mini-game available for use. Browse a maze and open AI generated diablo loot via http://Scenario.gg",
+        "categories": ["gaming", "ai", "rpg"],
         "ogImage": "https://0xsequence-demos.github.io/demo-lootbox/assets/maze-95401e2d.png",
         "originChainId": 42170,
         "originAddress": "0xaf8a08bf8b2945c2779ae507dade15985ea11fbc"

--- a/index/arbitrum-nova/erc20.json
+++ b/index/arbitrum-nova/erc20.json
@@ -32,7 +32,7 @@
       "extensions": {
         "link": "https://makerdao.com/",
         "description": "Dai is the native stablecoin for the Maker protocol. It is the world’s first crypto-collateralized and decentralized stablecoin, whose value is soft pegged to the US Dollar. The collateralized assets backing Dai are other cryptocurrencies instead of fiat and are held within smart contracts rather than in institutions.",
-        "categories": ["usd-stablecoin", "transactional", "defi", "protocol", "maker"],
+        "categories": ["usd-stablecoin", "stablecoin", "transactional", "defi", "protocol", "maker"],
         "ogImage": "https://makerdao.com/dai.png",
         "originChainId": 1,
         "originAddress": "0x6B175474E89094C44Da98b954EedeAC495271d0F"

--- a/index/arbitrum-nova/erc20.json
+++ b/index/arbitrum-nova/erc20.json
@@ -16,6 +16,7 @@
       "extensions": {
         "link": "https://www.circle.com/en/usdc",
         "description": "USDC is a fully collateralized US dollar stablecoin. USDC is the bridge between dollars and trading on cryptocurrency exchanges. The technology behind CENTRE makes it possible to exchange value between people, businesses and financial institutions just like email between mail services and texts between SMS providers. We believe by removing artificial economic borders, we can create a more inclusive global economy. ",
+        "categories": ["usd-stablecoin", "transactional", "usdc"],
         "ogImage": "https://www.circle.com/hubfs/share-USDC.png#keepProtocol",
         "originChainId": 1,
         "originAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
@@ -31,6 +32,7 @@
       "extensions": {
         "link": "https://makerdao.com/",
         "description": "Dai is the native stablecoin for the Maker protocol. It is the world’s first crypto-collateralized and decentralized stablecoin, whose value is soft pegged to the US Dollar. The collateralized assets backing Dai are other cryptocurrencies instead of fiat and are held within smart contracts rather than in institutions.",
+        "categories": ["usd-stablecoin", "transactional", "defi", "protocol", "maker"],
         "ogImage": "https://makerdao.com/dai.png",
         "originChainId": 1,
         "originAddress": "0x6B175474E89094C44Da98b954EedeAC495271d0F"
@@ -47,6 +49,7 @@
       "extensions": {
         "link": "https://weth.io/",
         "description": "W-ETH is \"wrapped ETH\" but let's start by introducing the players. First, there's Ether token. Ether or ETH is the native currency built on the Ethereum blockchain.\r\nSecond, there are alt tokens. When a dApp (decentralized app) is built off of the Ethereum Blockchain it usually implements it’s own form of Token. Think Augur’s REP Token, or Bancor's BNT Token. Finally the ERC-20 standard. ERC20 is a standard developed after the release of ETH that defines how tokens are transferred and how to keep a consistent record of those transfers among tokens in the Ethereum Network.",
+        "categories": ["defi", "protocol", "chain", "wrapped"],
         "ogImage": "https://makerdao.com/dai.png",
         "originChainId": 1,
         "originAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"

--- a/index/arbitrum/erc1155.json
+++ b/index/arbitrum/erc1155.json
@@ -16,6 +16,7 @@
       "extensions": {
         "link": "https://lore.bridgeworld.treasure.lol/",
         "description": "Treasures are composable building blocks in Bridgeworld that will be used inter- and intra-metaverse.",
+        "categories": ["gaming", "mmo", "strategy"],
         "ogImage": "https://djmahssgw62sw.cloudfront.net/0/Trove_Banner_XL_Other_1024x256px.jpg"
       }
     },
@@ -29,6 +30,7 @@
       "extensions": {
         "link": "https://www.talesofelleria.com/",
         "description": "Tales of Elleria is an immersive three-dimensional role-playing GameFi project built on Arbitrum One. Summon heroes, take on assignments, go on quests and epic adventures to battle dangerous monsters and earn tremendous rewards.",
+        "categories": ["gaming", "rpg", "mmo", "strategy"],
         "ogImage": "https://i.seadn.io/gcs/files/5cf33d22f7ee87e3bdc2fa5ec6e96fb7.png?auto=format&w=2048"
       }
     }

--- a/index/arbitrum/erc20.json
+++ b/index/arbitrum/erc20.json
@@ -16,6 +16,7 @@
       "extensions": {
         "link": "https://www.circle.com/en/usdc",
         "description": "USDC is a fully collateralized US dollar stablecoin. USDC is the bridge between dollars and trading on cryptocurrency exchanges. The technology behind CENTRE makes it possible to exchange value between people, businesses and financial institutions just like email between mail services and texts between SMS providers. We believe by removing artificial economic borders, we can create a more inclusive global economy. ",
+        "categories": ["usd-stablecoin", "transactional", "usdc"],
         "ogImage": "https://www.circle.com/hubfs/share-USDC.png#keepProtocol",
         "originChainId": 1,
         "originAddress": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
@@ -31,6 +32,7 @@
       "extensions": {
         "link": "https://www.circle.com/en/usdc",
         "description": "USDC is a fully collateralized US dollar stablecoin. USDC is the bridge between dollars and trading on cryptocurrency exchanges. The technology behind CENTRE makes it possible to exchange value between people, businesses and financial institutions just like email between mail services and texts between SMS providers. We believe by removing artificial economic borders, we can create a more inclusive global economy. ",
+        "categories": ["usd-stablecoin", "transactional", "wrapped", "bridged", "usdc"],
         "ogImage": "https://www.circle.com/hubfs/share-USDC.png#keepProtocol",
         "originChainId": 1,
         "originAddress": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
@@ -46,6 +48,7 @@
       "extensions": {
         "link": "https://makerdao.com/",
         "description": "Dai is the native stablecoin for the Maker protocol. It is the world’s first crypto-collateralized and decentralized stablecoin, whose value is soft pegged to the US Dollar. The collateralized assets backing Dai are other cryptocurrencies instead of fiat and are held within smart contracts rather than in institutions.",
+        "categories": ["usd-stablecoin", "transactional", "defi", "protocol", "maker"],
         "ogImage": "https://makerdao.com/dai.png",
         "originChainId": 1,
         "originAddress": "0x6b175474e89094c44da98b954eedeac495271d0f"
@@ -61,6 +64,7 @@
       "extensions": {
         "link": "https://treasure.lol/",
         "description": "MAGIC is the native token of Treasure. Treasure is the decentralized video game console connecting games and communities together through imagination, MAGIC, and NFTs.",
+        "categories": ["value", "governance", "transactional", "gaming", "reward", "treasure"],
         "ogImage": null
       }
     },
@@ -74,6 +78,7 @@
       "extensions": {
         "link": "https://www.talesofelleria.com/",
         "description": "Ellerium ($ELM) is a rare natural resource found within the world of Elleria. It is said to be the crystallized blessing of the Goddess and functions as the main currency throughout the whole metaverse.",
+        "categories": ["transactional", "reward", "gaming", "rpg", "mmo", "fantasy", "strategy"],
         "ogImage": null
       }
     },
@@ -87,7 +92,8 @@
       "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
       "extensions": {
         "link": "https://weth.io/",
-        "description": "W-ETH is \"wrapped ETH\" but let's start by introducing the players. First, there's Ether token. Ether or ETH is the native currency built on the Ethereum blockchain.\r\nSecond, there are alt tokens. When a dApp (decentralized app) is built off of the Ethereum Blockchain it usually implements it’s own form of Token. Think Augur’s REP Token, or Bancor's BNT Token. Finally the ERC-20 standard. ERC20 is a standard developed after the release of ETH that defines how tokens are transferred and how to keep a consistent record of those transfers among tokens in the Ethereum Network."
+        "description": "W-ETH is \"wrapped ETH\" but let's start by introducing the players. First, there's Ether token. Ether or ETH is the native currency built on the Ethereum blockchain.\r\nSecond, there are alt tokens. When a dApp (decentralized app) is built off of the Ethereum Blockchain it usually implements it’s own form of Token. Think Augur’s REP Token, or Bancor's BNT Token. Finally the ERC-20 standard. ERC20 is a standard developed after the release of ETH that defines how tokens are transferred and how to keep a consistent record of those transfers among tokens in the Ethereum Network.",
+        "categories": ["defi", "protocol", "chain", "wrapped"]
       }
     },
     {
@@ -100,7 +106,8 @@
       "logoURI": "https://assets.coingecko.com/coins/images/17995/small/LS_wolfDen_logo.0025_Light_200x200.png?1665110310",
       "extensions": {
         "link": "https://guardfdn.com/",
-        "description": "Guardian is for purpose driven companies and projects building and contributing to the web3 economy."
+        "description": "Guardian is for purpose driven companies and projects building and contributing to the web3 economy.",
+        "categories": ["governance", "protocol", "defi", "access"]
       }
     }
   ],

--- a/index/arbitrum/erc20.json
+++ b/index/arbitrum/erc20.json
@@ -48,7 +48,7 @@
       "extensions": {
         "link": "https://makerdao.com/",
         "description": "Dai is the native stablecoin for the Maker protocol. It is the world’s first crypto-collateralized and decentralized stablecoin, whose value is soft pegged to the US Dollar. The collateralized assets backing Dai are other cryptocurrencies instead of fiat and are held within smart contracts rather than in institutions.",
-        "categories": ["usd-stablecoin", "transactional", "defi", "protocol", "maker"],
+        "categories": ["usd-stablecoin", "stablecoin", "transactional", "defi", "protocol", "maker"],
         "ogImage": "https://makerdao.com/dai.png",
         "originChainId": 1,
         "originAddress": "0x6b175474e89094c44da98b954eedeac495271d0f"

--- a/index/arbitrum/erc721.json
+++ b/index/arbitrum/erc721.json
@@ -16,6 +16,7 @@
       "extensions": {
         "link": "https://spectralsignal.io",
         "description": "Begin your journey at the Starport Marketplace, your go-to hub for acquiring pre-owned and specialized spacecraft in the Spectral Signal universe. We're summoning intrepid travellers to probe the enigmatic signals and secrets lurking beyond. Select your ships, tailor your combat tactics with unique ship features, and seek out hidden riches—if only you can overcome the risks and return intact. Trade, engage, and navigate your journey in a realm that rewards the courageous.",
+        "categories": ["gaming", "rpg", "strategy", "mmo", "puzzle", "sci-fi"],
         "ogImage": "https://storage.googleapis.com/sequence-prod-cluster-builder/projects/23530/landingBannerUrl/a5e3f7818e23daf64a822c4bf510af703430a00d45cff488ac42cf34b9b7276d.jpeg"
       }
     },
@@ -26,6 +27,7 @@
       "type": "ERC721",
       "symbol": "GTPet2",
       "extensions": {
+        "categories": ["gaming", "rpg", "action", "fantasy"]
       }
     },
     {
@@ -35,6 +37,7 @@
       "type": "ERC721",
       "symbol": "FFC",
       "extensions": {
+        "categories": ["gaming", "simulation", "sports", "tcg"]
       }
     },
     {
@@ -44,6 +47,7 @@
       "type": "ERC721",
       "symbol": "FFP",
       "extensions": {
+        "categories": ["gaming", "simulation", "sports", "tcg"]
       }
     }
   ],

--- a/index/astar-zkevm/erc1155.json
+++ b/index/astar-zkevm/erc1155.json
@@ -17,6 +17,7 @@
       "extensions": {
         "link": "https://yoki.astar.network/en",
         "description": "Join the on-going Astar zkEVM launch campaign at Yoki.Astar.Network and begin collecting, fusing and discovering all the Yoki!",
+        "categories": ["gaming", "art", "reward", "adventure", "fantasy"],
         "ogImage": "https://assets.raribleuserdata.com/prod/v1/image/t_cover_big/aHR0cHM6Ly9pcGZzLnJhcmlibGV1c2VyZGF0YS5jb20vaXBmcy9iYWZ5YmVpZGp0a29iYTY2cng1cXRpZmFnM3htZmJneTV2bXJpYXJvdmVqNHFmN3lyZjYza2JndWp3cQ==",
         "originChainId": 3776,
         "originAddress": "0x2e6ff2a374844ed25e4523da53292a89b93e8905",

--- a/index/astar-zkevm/erc721.json
+++ b/index/astar-zkevm/erc721.json
@@ -17,6 +17,7 @@
       "extensions": {
         "link": "https://rarible.com/collection/astarzkevm/0x35edffb12f93253f1c567a7e207f06e1b0de9d8e/items",
         "description": "",
+        "categories": ["art", "access", "sci-fi"],
         "originChainId": 3776,
         "originAddress": "0x35edffb12f93253f1c567a7e207f06e1b0de9d8e",
         "featured": true
@@ -33,6 +34,7 @@
       "extensions": {
         "link": "https://rarible.com/collection/astarzkevm/0x6d0fe26797e077b444fb8e8ff9a38a688beb317d/items",
         "description": "",
+        "categories": ["art", "rwa", "access"],
         "originChainId": 3776,
         "originAddress": "0x6d0fe26797e077b444fb8e8ff9a38a688beb317d",
         "featured": true
@@ -49,6 +51,7 @@
       "extensions": {
         "link": "https://rarible.com/meta-mazda/items",
         "description": "Japanese automotive company, Mazda’s iconic first NFT art design. <br/> These collection expressing possibility of Mazda’s new communication and new story creation in digital world. <br/>Items are very symbolic since these collection were released as a first challenge and has a potential to be continued into a series in future.<br/>We expressed Japanese touch through Mazda’s iconic MX-5 MIATA with subculture essence.",
+        "categories": ["art", "rwa", "access"],
         "originChainId": 3776,
         "originAddress": "0x8ade4c707630d2f3ab0e36cde5c81da8f56fe0b6",
         "featured": true
@@ -65,6 +68,7 @@
       "extensions": {
         "link": "https://rarible.com/collection/astarzkevm/0xde782cc4bf15df5791261c126da1942ba8d805c4/items",
         "description": "",
+        "categories": ["art", "rwa", "access"],
         "ogImage": "https://assets.raribleuserdata.com/prod/v1/image/t_cover_big/aHR0cHM6Ly9pcGZzLnJhcmlibGV1c2VyZGF0YS5jb20vaXBmcy9iYWZ5YmVpZGp0a29iYTY2cng1cXRpZmFnM3htZmJneTV2bXJpYXJvdmVqNHFmN3lyZjYza2JndWp3cQ==",
         "originChainId": 3776,
         "originAddress": "0xde782cc4bf15df5791261c126da1942ba8d805c4",
@@ -82,6 +86,7 @@
       "extensions": {
         "link": "https://rarible.com/collection/astarzkevm/0x6d99156004e7ddd41b3cbf7e60a8af2438609542/items",
         "description": "",
+        "categories": ["gaming", "art", "casual", "fantasy"],
         "originChainId": 3776,
         "originAddress": "0x6d99156004e7ddd41b3cbf7e60a8af2438609542",
         "featured": true
@@ -98,6 +103,7 @@
       "extensions": {
         "link": "https://rarible.com/collection/astarzkevm/0x6d99156004e7ddd41b3cbf7e60a8af2438609542/items",
         "description": "A collection of 8,888 intelligent yet reserved Hikikomoris, based in Astar zkEVM, have gathered to conquer all Layer 2s on the Ethereum blockchain. ",
+        "categories": ["art", "casual", "cyberpunk", "sci-fi"],
         "ogImage": "https://ipfs.raribleuserdata.com/ipfs/bafkreiaf6wufj37zlfajhmcjsiuhg6rducl27imurjci4y6du5wnj42hta",
         "originChainId": 3776,
         "originAddress": "0xaa7fbb96a1397898495e07afc022c341510fa24f",

--- a/index/avalanche-testnet/erc20.json
+++ b/index/avalanche-testnet/erc20.json
@@ -16,6 +16,7 @@
       "extensions": {
         "link": "https://www.circle.com/en/usdc",
         "description": "USDC is a fully collateralized US dollar stablecoin. USDC is the bridge between dollars and trading on cryptocurrency exchanges. The technology behind CENTRE makes it possible to exchange value between people, businesses and financial institutions just like email between mail services and texts between SMS providers. We believe by removing artificial economic borders, we can create a more inclusive global economy. ",
+        "categories": ["usd-stablecoin", "transactional", "usdc"],
         "ogImage": "https://www.circle.com/hubfs/share-USDC.png#keepProtocol"
       }
     }

--- a/index/avalanche-testnet/erc721.json
+++ b/index/avalanche-testnet/erc721.json
@@ -16,6 +16,7 @@
       "extensions": {
         "link": "https://app.raremind.com/",
         "description": "Play chess on any platform and earn rewards",
+        "categories": ["gaming", "art", "reward", "access"],
         "ogImage": "https://pbs.twimg.com/profile_banners/1571737206196244481/1672640150/1080x360"
       }
     }   

--- a/index/avalanche/erc1155.json
+++ b/index/avalanche/erc1155.json
@@ -16,6 +16,7 @@
       "extensions": {
         "link": "https://castlecrushgame.com/",
         "description": "Castle Crush is a mobile, free-to-play, real-time strategy game developed by Wildlife Studios. Ascended and Founder Chests contain playable NFT cards which generate $ACS through gameplay.",
+        "categories": ["gaming", "reward", "mmo", "strategy", "tcg", "fantasy"],
         "ogImage": "https://user-images.githubusercontent.com/1619025/192035870-2d3c1a12-6228-4363-b474-625ed58a25e9.jpeg"
       }
     }

--- a/index/avalanche/erc20.json
+++ b/index/avalanche/erc20.json
@@ -12,7 +12,13 @@
       "decimals": 18,
       "name": "Wrapped AVAX",
       "symbol": "WAVAX",
-      "logoURI": "https://raw.githubusercontent.com/traderjoe-xyz/joe-tokenlists/main/logos/0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7/logo.png"
+      "logoURI": "https://raw.githubusercontent.com/traderjoe-xyz/joe-tokenlists/main/logos/0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7/logo.png",
+      "extensions": {
+        "link": null,
+        "description": null,
+        "categories": ["governance", "chain", "gas", "infrastructure", "staking", "wrapped"],
+        "ogImage": null
+      }
     },
     {
       "chainId": 43114,
@@ -20,7 +26,13 @@
       "decimals": 18,
       "name": "Dai Stablecoin",
       "symbol": "DAI.e",
-      "logoURI": "https://raw.githubusercontent.com/traderjoe-xyz/joe-tokenlists/main/logos/0xd586E7F844cEa2F87f50152665BCbc2C279D8d70/logo.png"
+      "logoURI": "https://raw.githubusercontent.com/traderjoe-xyz/joe-tokenlists/main/logos/0xd586E7F844cEa2F87f50152665BCbc2C279D8d70/logo.png",
+      "extensions": {
+        "link": null,
+        "description": "Dai is the native stablecoin for the Maker protocol. It is the world’s first crypto-collateralized and decentralized stablecoin, whose value is soft pegged to the US Dollar. The collateralized assets backing Dai are other cryptocurrencies instead of fiat and are held within smart contracts rather than in institutions.",
+        "categories": ["usd-stablecoin", "stablecoin", "transactional", "defi", "protocol", "maker"],
+        "ogImage": null
+      }
     },
     {
       "chainId": 43114,
@@ -28,7 +40,13 @@
       "decimals": 18,
       "name": "ChainLink Token",
       "symbol": "LINK.e",
-      "logoURI": "https://raw.githubusercontent.com/traderjoe-xyz/joe-tokenlists/main/logos/0x5947BB275c521040051D82396192181b413227A3/logo.png"
+      "logoURI": "https://raw.githubusercontent.com/traderjoe-xyz/joe-tokenlists/main/logos/0x5947BB275c521040051D82396192181b413227A3/logo.png",
+      "extensions": {
+        "link": null,
+        "description": null,
+        "categories": ["governance", "transactional", "value", "infrastructure", "staking", "wrapped", "bridged"],
+        "ogImage": null
+      }
     },
     {
       "chainId": 43114,
@@ -36,7 +54,13 @@
       "decimals": 6,
       "name": "Tether Token - Bridged",
       "symbol": "USDT.e",
-      "logoURI": "https://raw.githubusercontent.com/traderjoe-xyz/joe-tokenlists/main/logos/0xc7198437980c041c805A1EDcbA50c1Ce5db95118/logo.png"
+      "logoURI": "https://raw.githubusercontent.com/traderjoe-xyz/joe-tokenlists/main/logos/0xc7198437980c041c805A1EDcbA50c1Ce5db95118/logo.png",
+      "extensions": {
+        "link": null,
+        "description": null,
+        "categories": ["usd-stablecoin", "transactional", "wrapped", "bridged"],
+        "ogImage": null
+      }
     },
     {
       "chainId": 43114,
@@ -44,7 +68,13 @@
       "decimals": 8,
       "name": "Wrapped BTC",
       "symbol": "WBTC.e",
-      "logoURI": "https://raw.githubusercontent.com/traderjoe-xyz/joe-tokenlists/main/logos/0x50b7545627a5162F82A992c33b87aDc75187B218/logo.png"
+      "logoURI": "https://raw.githubusercontent.com/traderjoe-xyz/joe-tokenlists/main/logos/0x50b7545627a5162F82A992c33b87aDc75187B218/logo.png",
+      "extensions": {
+        "link": null,
+        "description": null,
+        "categories": ["value", "reward", "infrastructure", "wrapped", "bridged"],
+        "ogImage": null
+      }
     },
     {
       "chainId": 43114,
@@ -52,7 +82,13 @@
       "decimals": 18,
       "name": "Wrapped Ether",
       "symbol": "WETH.e",
-      "logoURI": "https://raw.githubusercontent.com/traderjoe-xyz/joe-tokenlists/main/logos/0x49D5c2BdFfac6CE2BFdB6640F4F80f226bc10bAB/logo.png"
+      "logoURI": "https://raw.githubusercontent.com/traderjoe-xyz/joe-tokenlists/main/logos/0x49D5c2BdFfac6CE2BFdB6640F4F80f226bc10bAB/logo.png",
+      "extensions": {
+        "link": null,
+        "description": null,
+        "categories": ["defi", "protocol", "chain", "wrapped", "bridged"],
+        "ogImage": null
+      }
     },
     {
       "chainId": 43114,
@@ -60,7 +96,13 @@
       "decimals": 6,
       "name": "USD Coin - Bridged",
       "symbol": "USDC.e",
-      "logoURI": "https://raw.githubusercontent.com/traderjoe-xyz/joe-tokenlists/main/logos/0xA7D7079b0FEaD91F3e65f86E8915Cb59c1a4C664/logo.png"
+      "logoURI": "https://raw.githubusercontent.com/traderjoe-xyz/joe-tokenlists/main/logos/0xA7D7079b0FEaD91F3e65f86E8915Cb59c1a4C664/logo.png",
+      "extensions": {
+        "link": null,
+        "description": null,
+        "categories": ["usd-stablecoin", "transactional", "usdc", "wrapped", "bridged"],
+        "ogImage": null
+      }
     },
     {
       "chainId": 43114,
@@ -72,6 +114,7 @@
       "extensions": {
         "link": "https://www.realfevr.com/fevr",
         "description": "RealFevr is a company established in 2015 in the fantasy markets with a football fantasy leagues game that currently has over 2 Million downloads on iOS and Android. With the fantasy leagues concept proven, RealFevr is now working towards being one of the NFT industry leaders by having the first-ever fully licensed Football Video NFTs Marketplace. Its NFTs will also be integrated into the FEVR Battle Arena, a new trading moments game (Play and Earn) that’s currently in its alpha testing stage.",
+        "categories": ["gaming", "reward", "access", "simulation", "sports"],
         "ogImage": null,
         "originChainId": 56,
         "originAddress": "0x82030cdbd9e4b7c5bb0b811a61da6360d69449cc"
@@ -87,6 +130,7 @@
       "extensions": {
         "link": "https://www.circle.com/en/usdc",
         "description": "USDC is a fully collateralized US dollar stablecoin. USDC is the bridge between dollars and trading on cryptocurrency exchanges. The technology behind CENTRE makes it possible to exchange value between people, businesses and financial institutions just like email between mail services and texts between SMS providers. We believe by removing artificial economic borders, we can create a more inclusive global economy. ",
+        "categories": ["usd-stablecoin", "transactional", "usdc"],
         "ogImage": "https://www.circle.com/hubfs/share-USDC.png#keepProtocol"
       }
     }

--- a/index/avalanche/erc721.json
+++ b/index/avalanche/erc721.json
@@ -15,6 +15,7 @@
       "extensions": {
         "link": "https://raremind.com/",
         "description": "Buy the 0-0-0 digital card and get extra rewards",
+        "categories": ["gaming", "art", "reward"],
         "ogImage": "https://storage.googleapis.com/sequence-prod-cluster-builder/projects/1660/landingBannerUrl/dad070c7bc8d10a798149f1e7106b25e84c68f881f17193a8753b717ade5ba7f.png"
       }
     }

--- a/index/base/erc20.json
+++ b/index/base/erc20.json
@@ -16,6 +16,7 @@
       "extensions": {
         "link": "https://www.circle.com/en/usdc",
         "description": "USDC is a fully collateralized US dollar stablecoin. USDC is the bridge between dollars and trading on cryptocurrency exchanges. The technology behind CENTRE makes it possible to exchange value between people, businesses and financial institutions just like email between mail services and texts between SMS providers. We believe by removing artificial economic borders, we can create a more inclusive global economy. ",
+        "categories": ["usd-stablecoin", "transactional", "usdc"],
         "ogImage": "https://www.circle.com/hubfs/share-USDC.png#keepProtocol",
         "originChainId": 1,
         "originAddress": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
@@ -31,7 +32,8 @@
       "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
       "extensions": {
         "link": "https://weth.io/",
-        "description": "W-ETH is \"wrapped ETH\" but let's start by introducing the players. First, there's Ether token. Ether or ETH is the native currency built on the Ethereum blockchain.\r\nSecond, there are alt tokens. When a dApp (decentralized app) is built off of the Ethereum Blockchain it usually implements it’s own form of Token. Think Augur’s REP Token, or Bancor's BNT Token. Finally the ERC-20 standard. ERC20 is a standard developed after the release of ETH that defines how tokens are transferred and how to keep a consistent record of those transfers among tokens in the Ethereum Network."
+        "description": "W-ETH is \"wrapped ETH\" but let's start by introducing the players. First, there's Ether token. Ether or ETH is the native currency built on the Ethereum blockchain.\r\nSecond, there are alt tokens. When a dApp (decentralized app) is built off of the Ethereum Blockchain it usually implements it’s own form of Token. Think Augur’s REP Token, or Bancor's BNT Token. Finally the ERC-20 standard. ERC20 is a standard developed after the release of ETH that defines how tokens are transferred and how to keep a consistent record of those transfers among tokens in the Ethereum Network.",
+        "categories": ["defi", "protocol", "chain", "wrapped"]
       }
     },
     {
@@ -44,7 +46,8 @@
       "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
       "extensions": {
         "link": "https://weth.io/",
-        "description": "Coinbase Wrapped Staked ETH (cbETH) represents your staked Ethereum (ETH) in a tradable form. You can unwrap cbETH at any time. cbETH provides flexibility to sell, transfer, or use it. You can move cbETH to a personal wallet and trade it outside the Coinbase platform."
+        "description": "Coinbase Wrapped Staked ETH (cbETH) represents your staked Ethereum (ETH) in a tradable form. You can unwrap cbETH at any time. cbETH provides flexibility to sell, transfer, or use it. You can move cbETH to a personal wallet and trade it outside the Coinbase platform.",
+        "categories": ["defi", "protocol", "chain", "exchange", "smart-contract", "wrapped"]
       }
     },
     {
@@ -57,6 +60,7 @@
       "extensions": {
         "link": "https://makerdao.com/",
         "description": "Dai is the native stablecoin for the Maker protocol. It is the world’s first crypto-collateralized and decentralized stablecoin, whose value is soft pegged to the US Dollar. The collateralized assets backing Dai are other cryptocurrencies instead of fiat and are held within smart contracts rather than in institutions.",
+        "categories": ["usd-stablecoin", "stablecoin", "transactional", "defi", "protocol", "maker"],
         "ogImage": "https://makerdao.com/dai.png",
         "originChainId": 1,
         "originAddress": "0x6b175474e89094c44da98b954eedeac495271d0f"

--- a/index/base/erc721.json
+++ b/index/base/erc721.json
@@ -16,6 +16,7 @@
       "extensions": {
         "link": "https://opensea.io/collection/okgo-on-base-1",
         "description": "OKGO is a 100% generative on-chain CC0 card collection",
+        "categories": ["gaming", "art", "tcg"],
         "ogImage": "https://i.seadn.io/s/raw/files/a35928ac8cf52099bd0f5b611684d543.png",
         "originChainId": 8453,
         "originAddress": null

--- a/index/bnb-testnet/erc20.json
+++ b/index/bnb-testnet/erc20.json
@@ -16,6 +16,7 @@
       "extensions": {
         "link": "https://www.realfevr.com/fevr",
         "description": "RealFevr is a company established in 2015 in the fantasy markets with a football fantasy leagues game that currently has over 2 Million downloads on iOS and Android. With the fantasy leagues concept proven, RealFevr is now working towards being one of the NFT industry leaders by having the first-ever fully licensed Football Video NFTs Marketplace. Its NFTs will also be integrated into the FEVR Battle Arena, a new trading moments game (Play and Earn) that’s currently in its alpha testing stage.",
+        "categories": ["gaming", "reward", "access", "simulation", "sports"],
         "ogImage": null,
         "originChainId": 56,
         "originAddress": null

--- a/index/bnb/erc20.json
+++ b/index/bnb/erc20.json
@@ -16,6 +16,7 @@
       "extensions": {
         "link": "https://thetanarena.com/",
         "description": "Thetan Arena is an e-sport game based on Blockchain technology. You can gather your friends, form a team, battle with others and earn token rewards with just your skills. Thetan Arena's gameplay is designed to revolve around the combination of your personal skills and teamwork. Challenge yourself with various game modes: MOBA & Battle Royale, coming with monthly updates and attractive rewards. You are guaranteed a gaming experience that’s never been known before and also guaranteed to lose to anyone the second you pause the fighting, too. Gear your heroes up with a large selection of hundreds of weapons. You'd better come up with a good tactic as well because the most fierce war awaiting you right from the moment that starship drops you off on the battlefield.",
+        "categories": ["gaming", "reward", "transactional", "staking", "strategy", "fantasy"],
         "ogImage": null,
         "originChainId": 56,
         "originAddress": null
@@ -31,6 +32,7 @@
       "extensions": {
         "link": "https://thetanarena.com/",
         "description": "Thetan Arena is an e-sport game based on Blockchain technology. You can gather your friends, form a team, battle with others and earn token rewards with just your skills. Thetan Arena's gameplay is designed to revolve around the combination of your personal skills and teamwork. Challenge yourself with various game modes: MOBA & Battle Royale, coming with monthly updates and attractive rewards. You are guaranteed a gaming experience that’s never been known before and also guaranteed to lose to anyone the second you pause the fighting, too. Gear your heroes up with a large selection of hundreds of weapons. You'd better come up with a good tactic as well because the most fierce war awaiting you right from the moment that starship drops you off on the battlefield.",
+        "categories": ["gaming", "governance", "access", "staking", "strategy", "fantasy"],
         "ogImage": null,
         "originChainId": 56,
         "originAddress": null
@@ -46,6 +48,7 @@
       "extensions": {
         "link": "https://ethereum.org/",
         "description": "Ethereum is a global, open-source platform for decentralized applications. In other words, the vision is to create a world computer that anyone can build applications in a decentralized manner; while all states and data are distributed and publicly accessible. Ethereum supports smart contracts in which developers can write code in order to program digital value. Examples of decentralized apps (dapps) that are built on Ethereum includes token, non-fungible tokens, decentralized finance apps, lending protocol, decentralized exchanges, and much more.",
+        "categories": ["chain", "protocol", "governance", "gas", "smart-contract", "infrastructure", "reward", "staking"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
@@ -61,6 +64,7 @@
       "extensions": {
         "link": "https://polygon.technology/",
         "description": "Polygon Network provides scalable, secure and instant Ethereum transactions. It is built on an implementation of the PLASMA framework and functions as an off chain scaling solution. Polygon Network offers scalability solutions along with other tools to the developer ecosystem, which enable Polygon to seamlessly integrate with dApps while helping developers create an enhanced user experience.",
+        "categories": ["chain", "protocol", "governance", "gas", "smart-contract", "infrastructure", "reward", "staking", "layer2"],
         "ogImage": "/banners/matic-network-1x1.png",
         "originChainId": 1,
         "originAddress": "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0"
@@ -76,6 +80,7 @@
       "extensions": {
         "link": "http://fantom.foundation",
         "description": "FANTOM is a new DAG based Smart Contract platform that intends to solve the scalability issues of existing public distributed ledger technologies. \r\n\r\nThe platform intends to distinguish itself from the traditional block ledger-based storage infrastructure by attempting to employ an improved version of existing DAG-based pro-tocols. The FANTOM platform adopts a new protocol known as the “Lachesis Protocol” to maintain consensus. This protocol is intended to be integrated into the Fantom OPERA Chain. The aim is to allow applications built on top of the FANTOM OPERA Chain to enjoy instant transactions and near zero transaction costs for all users. \r\n\r\nThe mission of FANTOM is to provide compatibility between all transaction bodies around the world, and create an ecosystem which allows real-time transactions and data sharing with low cost.",
+        "categories": ["chain", "governance", "gas", "smart-contract", "infrastructure", "reward", "staking", "defi"],
         "ogImage": "https://fantomfoundation-prod-wp-website.s3.ap-southeast-2.amazonaws.com/wp-content/uploads/2021/01/19225127/Fantom-1.png",
         "originChainId": 1,
         "originAddress": "0x4E15361FD6b4BB609Fa63C81A2be19d873717870"
@@ -91,6 +96,7 @@
       "extensions": {
         "link": "https://www.binance.com/en/trade/BNB_USDT",
         "description": "A pegged token by Binance which gives you the joint benefits of open blockchain technology and traditional currency by converting your cash into a stable digital currency equivalent.",
+        "categories": ["usd-stablecoin", "stablecoin", "transactional", "defi", "bnb"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": null
@@ -106,6 +112,7 @@
       "extensions": {
         "link": "https://www.binance.com/",
         "description": "As the native coin of Binance Chain, BNB has multiple use cases: fueling transactions on the Chain, paying for transaction fees on Binance Exchange, making in-store payments, and many more.",
+        "categories": ["chain", "governance", "gas", "smart-contract", "infrastructure", "reward", "staking", "value", "access", "wrapped", "bnb"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0xB8c77482e45F1F44dE1745F52C74426C631bDD52"
@@ -121,6 +128,7 @@
       "extensions": {
         "link": "https://www.circle.com/en/usdc",
         "description": "USDC is a fully collateralized US dollar stablecoin. USDC is the bridge between dollars and trading on cryptocurrency exchanges. The technology behind CENTRE makes it possible to exchange value between people, businesses and financial institutions just like email between mail services and texts between SMS providers. We believe by removing artificial economic borders, we can create a more inclusive global economy. ",
+        "categories": ["usd-stablecoin", "transactional", "usdc"],
         "ogImage": "https://www.circle.com/hubfs/share-USDC.png#keepProtocol",
         "originChainId": 1,
         "originAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
@@ -136,6 +144,7 @@
       "extensions": {
         "link": "https://ripple.com/xrp/",
         "description": "XRP is a digital asset built for payments. It is the native digital asset on the XRP Ledger—an open-source, permissionless and decentralized blockchain technology that can settle transactions in 3-5 seconds.",
+        "categories": ["defi", "transactional", "gas", "chain", "infrastructure"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": null
@@ -151,6 +160,7 @@
       "extensions": {
         "link": "https://cardano.org/",
         "description": "Cardano (ADA) is a decentralized platform that will allow complex programmable transfers of value in a secure and scalable fashion. Cardano is built in the secure Haskell programming language.",
+        "categories": ["chain", "governance", "gas", "smart-contract", "infrastructure", "reward", "staking", "defi"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": null
@@ -166,6 +176,7 @@
       "extensions": {
         "link": "https://www.avalabs.org/",
         "description": "Avalanche is an umbrella platform for launching decentralized finance (DeFi) applications, financial assets, trading and other services.",
+        "categories": ["chain", "governance", "gas", "smart-contract", "infrastructure", "reward", "staking", "defi"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": null
@@ -181,6 +192,7 @@
       "extensions": {
         "link": "https://www.paxos.com/busd/",
         "description": "BUSD is a 1:1 USD-backed stablecoin approved by the New York State Department of Financial Services (NYDFS), issued in partnership with Paxos.",
+        "categories": ["usd-stablecoin", "transactional", "bnb"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x4Fabb145d64652a948d72533023f6E7A623C7C53"
@@ -196,6 +208,7 @@
       "extensions": {
         "link": "https://polkadot.network/",
         "description": "Polkadot is a blockchain project that aims to connect blockchains, to enable the transfer of value and logic across chains. DOT is the native coin of the network.",
+        "categories": ["chain", "governance", "gas", "smart-contract", "infrastructure", "reward", "staking", "access"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x7884F51dC1410387371ce61747CB6264E1dAeE0B"
@@ -211,6 +224,7 @@
       "extensions": {
         "link": "https://dogecoin.com/",
         "description": "Dogecoin (DOGE) is based on the popular \"doge\" Internet meme and features a Shiba Inu on its logo. Dogecoin's creators envisaged it as a fun, light-hearted cryptocurrency. that would have greater appeal beyond the core Bitcoin audience, since it was based on a dog meme.",
+        "categories": ["meme", "chain", "gas", "infrastructure", "reward"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": null
@@ -226,6 +240,7 @@
       "extensions": {
         "link": "https://www.kryptomon.co/",
         "description": "Kryptomons are digital collectible BEP721 NFT Token monsters built on the BSC blockchain. They can be bought and traded by using our dedicated BEP20 Token (KMON). Breed with other players to create new eggs with exciting traits and new levels of power.",
+        "categories": ["gaming", "governance", "staking", "transactional", "post-apocalypic", "rpg", "puzzle"],
         "ogImage": null,
         "originChainId": 56,
         "originAddress": null
@@ -241,6 +256,7 @@
       "extensions": {
         "link": "https://revomon.io/",
         "description": "Revomon is an online monster trainer RPG that fully integrates NFTs with cutting edge VR, allowing our players to create real value in a virtual world.",
+        "categories": ["gaming", "governance", "staking", "transactional", "fantasy", "adventure"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x155040625D7ae3e9caDA9a73E3E44f76D3Ed1409"
@@ -256,6 +272,7 @@
       "extensions": {
         "link": "https://www.realfevr.com/fevr",
         "description": "RealFevr is a company established in 2015 in the fantasy markets with a football fantasy leagues game that currently has over 2 Million downloads on iOS and Android. With the fantasy leagues concept proven, RealFevr is now working towards being one of the NFT industry leaders by having the first-ever fully licensed Football Video NFTs Marketplace. Its NFTs will also be integrated into the FEVR Battle Arena, a new trading moments game (Play and Earn) that’s currently in its alpha testing stage.",
+        "categories": ["gaming", "reward", "access", "simulation", "sports"],
         "ogImage": null,
         "originChainId": 56,
         "originAddress": null
@@ -271,6 +288,7 @@
       "extensions": {
         "link": "https://gamesforaliving.com",
         "description": "The Games for a living Token ($GFAL) is the utility token used in our Network and Games. This means that all the transactions in our Marketplace are executed using $GFAL. $GFAL is also the basis of the governance of the Games for a living Network & Games.",
+        "categories": ["gaming", "governance", "staking", "transactional", "access"],
         "ogImage": null,
         "originChainId": 56,
         "originAddress": null
@@ -286,7 +304,8 @@
       "logoURI": "https://assets.coingecko.com/coins/images/17995/small/LS_wolfDen_logo.0025_Light_200x200.png?1665110310",
       "extensions": {
         "link": "https://guardfdn.com/",
-        "description": "Guardian is for purpose driven companies and projects building and contributing to the web3 economy."
+        "description": "Guardian is for purpose driven companies and projects building and contributing to the web3 economy.",
+        "categories": ["governance", "protocol", "defi", "access"]
       }
     },
     {
@@ -299,6 +318,7 @@
       "extensions": {
         "link": "https://makerdao.com/",
         "description": "MakerDAO has launched Multi-collateral DAI (MCD). This token refers to the new DAI that is collaterized by multiple assets.\r\n",
+        "categories": ["usd-stablecoin", "stablecoin", "transactional", "defi", "protocol", "maker", "bnb"],
         "ogImage": "https://makerdao.com/dai.png"
       }
     }

--- a/index/gnosis/erc20.json
+++ b/index/gnosis/erc20.json
@@ -16,6 +16,7 @@
       "extensions": {
         "link": "https://www.circle.com/en/usdc",
         "description": "USDC is a fully collateralized US dollar stablecoin. USDC is the bridge between dollars and trading on cryptocurrency exchanges. The technology behind CENTRE makes it possible to exchange value between people, businesses and financial institutions just like email between mail services and texts between SMS providers. We believe by removing artificial economic borders, we can create a more inclusive global economy. ",
+        "categories": ["usd-stablecoin", "transactional", "usdc"],
         "ogImage": "https://www.circle.com/hubfs/share-USDC.png#keepProtocol"
       }
     },
@@ -29,6 +30,7 @@
       "extensions": {
         "link": "https://makerdao.com/",
         "description": "MakerDAO has launched Multi-collateral DAI (MCD). This token refers to the new DAI that is collaterized by multiple assets.\r\n",
+        "categories": ["usd-stablecoin", "stablecoin", "transactional", "defi", "protocol", "maker"],
         "ogImage": "https://makerdao.com/dai.png"
       }
     }

--- a/index/gnosis/erc721.json
+++ b/index/gnosis/erc721.json
@@ -16,6 +16,7 @@
       "extensions": {
         "link": "https://poap.xyz/",
         "description": "POAP, short for 'Proof of Attendance Protocol,' allows you to mint memories as digital mementos we call 'POAPs.' Give POAPs to people for sharing a memory with you.",
+        "categories": ["art", "reward", "access"],
         "originAddress": "0x22C1f6050E56d2876009903609a2cC3fEf83B415"
       }
     }

--- a/index/mumbai/erc1155.json
+++ b/index/mumbai/erc1155.json
@@ -16,6 +16,7 @@
       "extensions": {
         "link": "https://www.skyweaver.net/",
         "description": "Skyweaver is a Free-to-Play, trading card game powered by Polygon and Ethereum.",
+        "categories": ["gaming", "art", "skyweaver", "tcg", "strategy", "fantasy"],
         "ogImage": "https://skyweaver.net/images/skyweavercover.jpg",
         "originChainId": 80001,
         "originAddress": "0x631998e91476DA5B870D741192fc5Cbc55F5a52E",

--- a/index/mumbai/erc20.json
+++ b/index/mumbai/erc20.json
@@ -16,6 +16,7 @@
       "extensions": {
         "link": "https://www.circle.com/en/usdc",
         "description": "TEST CURRENCY, NOT THE REAL USDC. USDC is a token tracking the price of 1 USD.",
+        "categories": ["usd-stablecoin", "transactional", "usdc"],
         "ogImage": "https://www.circle.com/hubfs/share-USDC.png#keepProtocol",
         "originChainId": 80001,
         "originAddress": ""

--- a/index/mumbai/erc721.json
+++ b/index/mumbai/erc721.json
@@ -16,6 +16,7 @@
         "extensions": {
           "link": "https://www.planetmojo.io/",
           "description": "Planet Mojo is a magical and imaginative Web3 gaming metaverse platform being built by an accomplished team of industry veterans. Players compete with customized teams of mythical creatures in a suite of eSports, PvP games, set on a mysterious alien planet with a deep narrative that’s revealed by discovery and time. The long-term goal is to create a sustainable and expansive suite of games for the next generation of gamers, where they own their in-game assets and have a say in the project’s future direction.",
+          "categories": ["gaming", "art", "ai", "access", "fantasy"],
           "ogImage": "https://img.api.cryptorank.io/coins/planet_mojo1678714578583.png"
         }
       }

--- a/index/mumbai/misc.json
+++ b/index/mumbai/misc.json
@@ -1,1 +1,10 @@
-{}
+{
+  "name": "sequence-misc-mumbai",
+  "chainId": 80001,
+  "logoURI": "https://avatars.githubusercontent.com/u/35579638?s=400&u=41e1dbfbbf6f98037069c918c9383ffb8e978fb7&v=4",
+  "keywords": ["misc", "mumbai"],
+  "timestamp": "2022-03-14T23:27:42.783Z",
+  "tokens": [
+  ],
+  "version": { "major": 1, "minor": 0, "patch": 0 }
+}

--- a/index/optimism/erc20.json
+++ b/index/optimism/erc20.json
@@ -649,7 +649,7 @@
       "logoURI": "https://ethereum-optimism.github.io/data/USDT/logo.png",
       "extensions": {
         "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
-        "categories": ["usd-stablecoin", "transactional", "usdc"]
+        "categories": ["usd-stablecoin", "transactional", "usdt"]
       }
     },
     {

--- a/index/optimism/erc20.json
+++ b/index/optimism/erc20.json
@@ -16,6 +16,7 @@
       "extensions": {
         "link": "https://www.circle.com/en/usdc",
         "description": "USDC is a fully collateralized US dollar stablecoin. USDC is the bridge between dollars and trading on cryptocurrency exchanges. The technology behind CENTRE makes it possible to exchange value between people, businesses and financial institutions just like email between mail services and texts between SMS providers. We believe by removing artificial economic borders, we can create a more inclusive global economy. ",
+        "categories": ["usd-stablecoin", "transactional", "usdc"],
         "ogImage": "https://www.circle.com/hubfs/share-USDC.png#keepProtocol",
         "originChainId": 1,
         "originAddress": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32,6 +33,7 @@
       "extensions": {
         "link": "https://makerdao.com/",
         "description": "Dai is the native stablecoin for the Maker protocol. It is the world’s first crypto-collateralized and decentralized stablecoin, whose value is soft pegged to the US Dollar. The collateralized assets backing Dai are other cryptocurrencies instead of fiat and are held within smart contracts rather than in institutions.",
+        "categories": ["usd-stablecoin", "stablecoin", "transactional", "defi", "protocol", "maker"],
         "ogImage": "https://makerdao.com/dai.png",
         "originChainId": 1,
         "originAddress": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -46,7 +48,8 @@
       "decimals": 8,
       "logoURI": "https://ethereum-optimism.github.io/data/0xBTC/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["value", "defi", "protocol", "stablecoin"]
       }
     },
     {
@@ -57,7 +60,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/AAVE/logo.svg",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["governance", "defi", "lending", "protocol", "reward", "staking", "aave"]
       }
     },
     {
@@ -68,7 +72,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/AELIN/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["governance", "defi", "access", "protocol", "reward", "staking"]
       }
     },
     {
@@ -79,7 +84,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/BAL/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["governance", "defi", "access", "protocol", "reward", "staking", "exchange", "balancer"]
       }
     },
     {
@@ -90,7 +96,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/BitANT/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["governance", "chain", "smart-contract"]
       }
     },
     {
@@ -101,7 +108,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/BitBTC/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x158F513096923fF2d3aab2BcF4478536de6725e2"
+        "optimismBridgeAddress": "0x158F513096923fF2d3aab2BcF4478536de6725e2",
+        "categories": ["value", "defi", "wrapped"]
       }
     },
     {
@@ -112,7 +120,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/BOND/logo.svg",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["governance", "defi", "protocol", "staking", "reward"]
       }
     },
     {
@@ -123,7 +132,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/CRV/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["governance", "defi", "protocol", "staking", "reward", "access", "curve"]
       }
     },
     {
@@ -134,7 +144,8 @@
       "decimals": 0,
       "logoURI": "https://ethereum-optimism.github.io/data/DCN/logo.svg",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["governance", "transactional", "rwa", "access", "infrastructure"]
       }
     },
     {
@@ -145,7 +156,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/DF/logo.svg",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["governance", "transactional", "defi", "access", "lending", "reward", "staking"]
       }
     },
     {

--- a/index/optimism/erc20.json
+++ b/index/optimism/erc20.json
@@ -600,7 +600,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/TUSD/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["usd-stablecoin", "transactional"]
       }
     },
     {
@@ -611,7 +612,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/UMA/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["governance", "defi", "protocol", "reward", "staking", "access"]
       }
     },
     {
@@ -622,7 +624,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/UNI/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["exchange", "governance", "defi", "uniswap"]
       }
     },
     {
@@ -633,7 +636,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/USDD/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["usd-stablecoin", "stablecoin", "transactional"]
       }
     },
     {
@@ -644,7 +648,8 @@
       "decimals": 6,
       "logoURI": "https://ethereum-optimism.github.io/data/USDT/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["usd-stablecoin", "transactional", "usdc"]
       }
     },
     {
@@ -655,7 +660,8 @@
       "decimals": 6,
       "logoURI": "https://ethereum-optimism.github.io/data/UST/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["usd-stablecoin", "stablecoin", "transactional", "wrapped"]
       }
     },
     {
@@ -666,7 +672,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/USX/logo.svg",
       "extensions": {
-        "optimismBridgeAddress": "0xc76cbFbAfD41761279E3EDb23Fd831Ccb74D5D67"
+        "optimismBridgeAddress": "0xc76cbFbAfD41761279E3EDb23Fd831Ccb74D5D67",
+        "categories": ["usd-stablecoin", "stablecoin", "transactional", "defi", "protocol", "reward"]
       }
     },
     {
@@ -677,7 +684,8 @@
       "decimals": 8,
       "logoURI": "https://ethereum-optimism.github.io/data/WBTC/logo.svg",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["value", "reward", "infrastructure", "wrapped", "bridged"]
       }
     },
     {
@@ -688,7 +696,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/WETH/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["defi", "protocol", "chain", "wrapped"]
       }
     },
     {
@@ -699,7 +708,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/XCHF/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["stablecoin", "transactional"]
       }
     },
     {
@@ -710,7 +720,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/ZRX/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["exchange", "transactional", "governance", "staking", "reward"]
       }
     }
   ],

--- a/index/optimism/erc20.json
+++ b/index/optimism/erc20.json
@@ -168,7 +168,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/DHT/logo.svg",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["governance", "defi", "access", "reward", "staking"]
       }
     },
     {
@@ -179,7 +180,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/DOLA/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["usd-stablecoin", "usd-stablecoin", "defi", "lending", "reward"]
       }
     },
     {
@@ -190,7 +192,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/ENS/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["infrastructure", "access", "value"]
       }
     },
     {
@@ -201,7 +204,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/EQZ/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["governance", "defi", "lending", "access"]
       }
     },
     {
@@ -212,7 +216,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/EST/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["access", "reward"]
       }
     },
     {
@@ -223,7 +228,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/ETH/logo.svg",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["chain", "protocol", "governance", "gas", "smart-contract", "infrastructure", "reward", "staking"]
       }
     },
     {
@@ -234,7 +240,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/GTC/logo.svg",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["governance", "staking", "reward", "access"]
       }
     },
     {
@@ -245,7 +252,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/GYSR/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["infrastructure", "staking", "reward", "access"]
       }
     },
     {
@@ -256,7 +264,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/KNC/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["governance", "staking", "reward", "defi", "transactional"]
       }
     },
     {
@@ -267,7 +276,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/KROM/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["defi", "protocol", "staking", "reward", "exchange", "governance", "transactional"]
       }
     },
     {
@@ -278,7 +288,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/LINK/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["governance", "transactional", "value", "infrastructure", "staking"]
       }
     },
     {
@@ -289,7 +300,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/LIZ/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["meme"]
       }
     },
     {
@@ -300,7 +312,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/LRC/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["chain", "layer2", "governance", "infrastructure", "transactional"]
       }
     },
     {
@@ -311,7 +324,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/LUSD/logo.svg",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["usd-stablecoin", "stablecoin", "transactional", "defi"]
       }
     },
     {
@@ -322,7 +336,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/LYRA/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["governance", "defi", "access", "exchange"]
       }
     },
     {
@@ -333,7 +348,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/MASK/logo.svg",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["governance", "protocol", "access", "infrastructure"]
       }
     },
     {
@@ -344,7 +360,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/MKR/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1"
+        "optimismBridgeAddress": "0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1",
+        "categories": ["governance", "defi", "access", "transactional", "maker"]
       }
     },
     {
@@ -355,7 +372,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/MKR/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["governance", "defi", "access", "transactional", "maker"]
       }
     },
     {
@@ -366,7 +384,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/OP/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["chain", "governance", "gas", "smart-contract", "infrastructure", "staking", "reward", "layer2"]
       }
     },
     {
@@ -377,7 +396,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/PAPER/logo.svg",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["gaming", "simulation", "rpg", "strategy"]
       }
     },
     {
@@ -388,7 +408,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/PERP/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["defi", "exchange", "governance", "staking", "reward"]
       }
     },
     {
@@ -399,7 +420,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/POOL/logo.svg",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["governance", "defi", "access", "reward", "staking"]
       }
     },
     {
@@ -410,7 +432,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/PREMIA/logo.svg",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["governance", "defi", "access", "reward", "staking"]
       }
     },
     {
@@ -421,7 +444,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/RAI/logo.svg",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["stablecoin", "transactional", "defi", "protocol"]
       }
     },
     {
@@ -432,7 +456,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/rETH/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["defi", "staking", "reward", "protocol"]
       }
     },
     {
@@ -443,7 +468,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/RGT/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["defi", "governance", "access"]
       }
     },
     {
@@ -454,7 +480,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/SARCO/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["protocol", "staking", "access", "governance"]
       }
     },
     {
@@ -465,7 +492,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/sBTC/logo.svg",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["defi", "protocol", "staking", "reward", "access", "synthetix"]
       }
     },
     {
@@ -476,7 +504,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/sETH/logo.svg",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["defi", "protocol", "staking", "reward", "access", "synthetix"]
       }
     },
     {
@@ -487,7 +516,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/sLINK/logo.svg",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["defi", "protocol", "staking", "reward", "access", "synthetix"]
       }
     },
     {
@@ -498,7 +528,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/SNX/logo.svg",
       "extensions": {
-        "optimismBridgeAddress": "0x136b1EC699c62b0606854056f02dC7Bb80482d63"
+        "optimismBridgeAddress": "0x136b1EC699c62b0606854056f02dC7Bb80482d63",
+        "categories": ["defi", "protocol", "staking", "reward", "access", "synthetix"]
       }
     },
     {
@@ -509,7 +540,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/SPANK/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["infrastructure", "access", "staking"]
       }
     },
     {
@@ -520,7 +552,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/SUKU/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["infrastructure", "access", "staking", "rwa", "governance"]
       }
     },
     {
@@ -531,7 +564,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/sUSD/logo.svg",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["usd-stablecoin", "stablecoin", "defi", "protocol", "synthetix"]
       }
     },
     {
@@ -542,7 +576,8 @@
       "decimals": 18,
       "logoURI": "https://ethereum-optimism.github.io/data/THALES/logo.png",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["defi", "staking", "reward", "protocol", "access", "sports"]
       }
     },
     {
@@ -553,7 +588,8 @@
       "decimals": 16,
       "logoURI": "https://ethereum-optimism.github.io/data/TheDAO/logo.svg",
       "extensions": {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010"
+        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
+        "categories": ["governance", "access"]
       }
     },
     {

--- a/index/polygon-zkevm/erc1155.json
+++ b/index/polygon-zkevm/erc1155.json
@@ -16,6 +16,7 @@
       "extensions": {
         "link": "https://sequence.xyz/",
         "description": "From Sequence's vault of mystery, We bring to you a puzzle, a work of artistry. Piece by piece, each fragment holds a clue, To a masterpiece hidden, for the lucky few.",
+        "categories": ["art", "gaming", "puzzle"],
         "ogImage": "https://sequence.xyz/social-share.jpg"
       }
     }

--- a/index/polygon-zkevm/erc20.json
+++ b/index/polygon-zkevm/erc20.json
@@ -16,6 +16,7 @@
       "extensions": {
         "link": "https://www.circle.com/en/usdc",
         "description": "USDC is a fully collateralized US dollar stablecoin. USDC is the bridge between dollars and trading on cryptocurrency exchanges. The technology behind CENTRE makes it possible to exchange value between people, businesses and financial institutions just like email between mail services and texts between SMS providers. We believe by removing artificial economic borders, we can create a more inclusive global economy. ",
+        "categories": ["usd-stablecoin", "transactional", "usdc"],
         "ogImage": "https://www.circle.com/hubfs/share-USDC.png#keepProtocol",
         "originChainId": 1,
         "originAddress": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
@@ -31,6 +32,7 @@
       "extensions": {
         "link": "https://polygon.technology/matic-token",
         "description": "MATIC is the currency of Polygon that enables users to interact with tens of thousands of dApps involved in our ecosystem. It is also used to secure the network by staking.",
+        "categories": ["chain", "protocol", "governance", "gas", "smart-contract", "infrastructure", "reward", "staking", "layer2"],
         "originChainId": 137
       }
     },
@@ -44,6 +46,7 @@
       "extensions": {
         "link": "https://polygon.technology/pol-token",
         "description": "POL is the currency of Polygon that enables users to interact with tens of thousands of dApps involved in our ecosystem. It is also used to secure the network by staking.",
+        "categories": ["chain", "protocol", "governance", "gas", "smart-contract", "infrastructure", "reward", "staking", "layer2"],
         "originChainId": 137
       }
     },
@@ -57,6 +60,7 @@
       "extensions": {
         "link": "https://tether.to/",
         "description": "Tether (USDT) is a cryptocurrency with a value meant to mirror the value of the U.S. dollar. The idea was to create a stable cryptocurrency that can be used like digital dollars. Coins that serve this purpose of being a stable dollar substitute are called “stable coins.” Tether is the most popular stable coin and even acts as a dollar replacement on many popular exchanges! According to their site, Tether converts cash into digital currency, to anchor or “tether” the value of the coin to the price of national currencies like the US dollar, the Euro, and the Yen. Like other cryptos it uses blockchain. Unlike other cryptos, it is [according to the official Tether site] “100% backed by USD” (USD is held in reserve). The primary use of Tether is that it offers some stability to the otherwise volatile crypto space and offers liquidity to exchanges who can’t deal in dollars and with banks (for example to the sometimes controversial but leading exchange <a href=\"https://www.coingecko.com/en...",
+        "categories": ["usd-stablecoin", "transactional", "usdc"],
         "ogImage": "https://tether.to/wp-content/uploads/2020/09/tether-preview.png"
       }
     },
@@ -70,7 +74,8 @@
       "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
       "extensions": {
         "link": "https://weth.io/",
-        "description": "W-ETH is \"wrapped ETH\" but let's start by introducing the players. First, there's Ether token. Ether or ETH is the native currency built on the Ethereum blockchain.\r\nSecond, there are alt tokens. When a dApp (decentralized app) is built off of the Ethereum Blockchain it usually implements it’s own form of Token. Think Augur’s REP Token, or Bancor's BNT Token. Finally the ERC-20 standard. ERC20 is a standard developed after the release of ETH that defines how tokens are transferred and how to keep a consistent record of those transfers among tokens in the Ethereum Network."
+        "description": "W-ETH is \"wrapped ETH\" but let's start by introducing the players. First, there's Ether token. Ether or ETH is the native currency built on the Ethereum blockchain.\r\nSecond, there are alt tokens. When a dApp (decentralized app) is built off of the Ethereum Blockchain it usually implements it’s own form of Token. Think Augur’s REP Token, or Bancor's BNT Token. Finally the ERC-20 standard. ERC20 is a standard developed after the release of ETH that defines how tokens are transferred and how to keep a consistent record of those transfers among tokens in the Ethereum Network.",
+        "categories": ["defi", "protocol", "chain", "wrapped"]
       }
     },{
       "chainId": 1101,
@@ -82,6 +87,7 @@
       "extensions": {
         "link": "https://www.wbtc.network/",
         "description": null,
+        "categories": ["value", "reward", "infrastructure", "wrapped", "bridged"],
         "ogImage": "https://wbtc.network/assets/WBTC-icon.svg"
       }
     },
@@ -95,6 +101,7 @@
       "extensions": {
         "link": "https://makerdao.com/",
         "description": "MakerDAO has launched Multi-collateral DAI (MCD). This token refers to the new DAI that is collaterized by multiple assets.\r\n",
+        "categories": ["usd-stablecoin", "stablecoin", "transactional", "defi", "protocol", "maker"],
         "ogImage": "https://makerdao.com/dai.png"
       }
     }

--- a/index/polygon/erc1155.json
+++ b/index/polygon/erc1155.json
@@ -16,6 +16,7 @@
       "extensions": {
         "link": "https://www.skyweaver.net/",
         "description": "Skyweaver is a Free-to-Play, trading card game powered by Polygon and Ethereum.",
+        "categories": ["gaming", "tcg", "skyweaver"],
         "ogImage": "https://skyweaver.net/images/skyweavercover.jpg",
         "originChainId": 137,
         "originAddress": "0x631998e91476DA5B870D741192fc5Cbc55F5a52E",
@@ -33,6 +34,7 @@
       "extensions": {
         "link": "https://www.skyweaver.net/",
         "description": "Skyweaver is a Free-to-Play, trading card game powered by Ethereum.",
+        "categories": ["gaming", "tcg", "skyweaver"],
         "ogImage": "https://skyweaver.net/images/skyweavercover.jpg",
         "originChainId": 137,
         "originAddress": "0x5151bFa48249C57695336C66d51054c9367f6D33",
@@ -50,6 +52,7 @@
       "extensions": {
         "link": "https://www.skyweaver.net/",
         "description": "Skyweaver is a Free-to-Play, trading card game powered by Ethereum.",
+        "categories": ["gaming", "tcg", "skyweaver"],
         "ogImage": "https://skyweaver.net/images/skyweavercover.jpg",
         "originChainId": 137,
         "originAddress": "0xDFd64eE208629DCb1cEF4a148c50Bb3079D449e3",
@@ -67,6 +70,7 @@
       "extensions": {
         "link": "https://www.skyweaver.net/",
         "description": "Skyweaver is a Free-to-Play, trading card game powered by Ethereum.",
+        "categories": ["gaming", "tcg", "skyweaver"],
         "ogImage": "https://skyweaver.net/images/skyweavercover.jpg",
         "originChainId": 137,
         "originAddress": "0xC4c544D22BCc110652944BcA5Cf6330dd04D081a",
@@ -84,6 +88,7 @@
       "extensions": {
         "link": "https://www.skyweaver.net/",
         "description": "Skyweaver is a Free-to-Play, trading card game powered by Ethereum.",
+        "categories": ["gaming", "tcg", "skyweaver"],
         "ogImage": "https://skyweaver.net/images/skyweavercover.jpg",
         "originChainId": 137,
         "originAddress": "0x87C8d4d17Dff2CD604c399a7d243eE0311581ec3",
@@ -102,6 +107,7 @@
       "extensions": {
         "link": null,
         "description": "Wrapped USDC into ERC-1155 token contract.",
+        "categories": ["usd-stablecoin", "transactional", "usdc", "wrapped"],
         "ogImage": null,
         "originChainId": 137,
         "originAddress": "0x0ce2ABE65F4F354321Fa9f000aC14b7A2B3F6f65"
@@ -118,6 +124,7 @@
       "extensions": {
         "link": null,
         "description": "TEST CURRENCY, NOT THE REAL DAI. DAI is a token tracking the price of 1 USD.",
+        "categories": ["usd-stablecoin", "stablecoin", "transactional", "defi", "protocol", "maker", "wrapped"],
         "ogImage": null,
         "originChainId": 137,
         "originAddress": "0xdde0A6b9617781b8984790F0d0a40232556869Dd",
@@ -136,6 +143,7 @@
       "extensions": {
         "link": null,
         "description": "TEST CURRENCY, NOT THE REAL DAI. DAI is a token tracking the price of 1 USD.",
+        "categories": ["usd-stablecoin", "stablecoin", "transactional", "defi", "protocol", "maker", "wrapped"],
         "ogImage": null,
         "originChainId": 137,
         "originAddress": "0xb634304708e3bf20B19472822DDDAd4CE59EE485",
@@ -153,6 +161,7 @@
       "extensions": {
         "link": null,
         "description": "TEST CURRENCY, NOT THE REAL DAI. DAI is a token tracking the price of 1 USD.",
+        "categories": ["usd-stablecoin", "stablecoin", "transactional", "defi", "protocol", "maker", "wrapped"],
         "ogImage": null,
         "originChainId": 137,
         "originAddress": "0xDbC352232F6B6A5a2f18Ea58DC9E79df59e54575",
@@ -170,6 +179,7 @@
       "extensions": {
         "link": null,
         "description": "TEST CURRENCY, NOT THE REAL DAI. DAI is a token tracking the price of 1 USD.",
+        "categories": ["usd-stablecoin", "stablecoin", "transactional", "defi", "protocol", "maker", "wrapped"],
         "ogImage": null,
         "originChainId": 137,
         "originAddress": "0x972A6BA04AE120F9B51F0770FEb03c1785877e4E",
@@ -186,6 +196,7 @@
       "extensions": {
         "link": "https://www.skyweaver.net/",
         "description": "Skyweaver is a Free-to-Play, trading card game powered by Ethereum.",
+        "categories": ["gaming", "tcg", "skyweaver"],
         "ogImage": "https://skyweaver.net/images/skyweavercover.jpg",
         "originChainId": 1,
         "originAddress": "0x2e56c100fae2e38c8447ac225d34a486700ea994",
@@ -203,6 +214,7 @@
       "extensions": {
         "link": "https://pepemon.finance/",
         "description": "Pepemon's Storefront - Come get your unique Gen1 Starter NFT's now!",
+        "categories": ["gaming", "reward", "tcg", "adventure"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0xcb6768a968440187157cfe13b67cac82ef6cc5a4"
@@ -218,6 +230,7 @@
       "extensions": {
         "link": "https://degacha.com/introduce/gacha",
         "description": "### THE WORLD’s FIRST BLOCKCHAIN GACHAPON MACHINE & PLATFORM\r\nGachapon (ガチャポン) refers to the crazy popular Japanese vending-machine style game in which players deposit coins to receive a capsule-ball containing a randomized collectible. Now you can experience the thrill of Gachapon anywhere in the world, while acquiring provably scarce & authentic digital collectibles backed by blockchain NFT technology\r\n\r\nhttps://degacha.com/introduce/gacha",
+        "categories": ["art", "gaming", "access", "tcg"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x7cdc0421469398e0f3aa8890693d86c840ac8931"
@@ -233,6 +246,7 @@
       "extensions": {
         "link": "https://bondly.finance",
         "description": "The Official Bondly Collectible Card Game",
+        "categories": ["art", "gaming", "reward", "access", "music", "sports"],
         "ogImage": "/assets/images/metaimg.png",
         "originChainId": 1,
         "originAddress": "0x8280d56ac92b5bff058d60c99932fdecdcc9441a"
@@ -248,6 +262,7 @@
       "extensions": {
         "link": "https://embersword.com/",
         "description": "Ember Sword is a Platform-Agnostic Free-to-Play MMORPG with a player-driven economy, a classless combat system, and scarce, tradable cosmetic collectibles and land. Ember Sword has the fast-paced combat of aRPGs, combined with the isometric view and skill-based abilities of MOBAs, set in a persistent MMORPG fantasy universe.",
+        "categories": ["gaming", "reward", "action", "rpg", "mmo"],
         "ogImage": "https://embersword.com/thumbnail.png"
       }
     },
@@ -261,6 +276,7 @@
       "extensions": {
         "link": "https://www.coolcatsnft.com/",
         "description": "Cool Pets love these items, I'm sure if you use enough of them on an egg they'll grow into a glorious Cool Pet. Also, there may be more than meets the eye to these items in the future... but there also may not.",
+        "categories": ["art", "access"],
         "ogImage": "https://lh3.googleusercontent.com/Vurdrs-QMNIHO6QXfEWlzXjfEnFaGfj8vNq34RErkLqqA7wDnuHNJfs4WWyb9NjFT7XQBcKCzyCTWCl6SMmFzNrHEPoI9kPd5F0p-g=h400"
       }
     },
@@ -274,6 +290,7 @@
       "extensions": {
         "link": "https://sunflower-land.com/",
         "description": "Sunflower Land is a NFT & Crypto-Farming Game on Polygon.Players must plant crops, chop wood, mine rocks and much more in their search for exotic and rare resources. Each item in this collection has a unique set of ingredients and total supply.",
+        "categories": ["art", "gaming", "access", "simulation"],
         "ogImage": "https://lh3.googleusercontent.com/nAa17XwBwDzX9fPFUtpTDFlzxlK_YCXSWhyzDioIzhhZ_NWGudNTacAcM79o3ss482y-KnatQWnF1ZIHjm8JEZXYsOfeRLXYUviqvA=h400",
         "featured": true
       }
@@ -288,6 +305,7 @@
       "extensions": {
         "link": "https://sunflower-land.com/",
         "description": "Make your Bumpkin Beautiful! Collect wearable items for your Bumpkin NFT. Each item in this collection is a SFT that can be attached to your Bumpkin.",
+        "categories": ["art", "gaming", "access", "simulation"],
         "ogImage": "https://i.seadn.io/gcs/files/76047949b2ec540d6ddf8545a01cbbf1.png?auto=format&w=3840"
       }
     },
@@ -301,6 +319,7 @@
       "extensions": {
         "link": "https://galaxyfightclub.com/",
         "description": "Key fragments or key shards are rewards won inside the Galaxy Fight Club game, they can be combined into key fragments which are used to open loot boxes on our website.",
+        "categories": ["gaming", "action", "pvp", "reward"],
         "ogImage": "https://i.seadn.io/gcs/files/b7bb2210dc0a798b8412d0a3d749e337.png?auto=format&w=3840"
       }
     },
@@ -314,6 +333,7 @@
       "extensions": {
         "link": "https://galaxyfightclub.com/",
         "description": "Keys are crafted from corresponding key fragments on our website, keys can be used to open loot boxes on our website to access loot like weapons and others",
+        "categories": ["gaming", "action", "pvp"],
         "ogImage": "https://i.seadn.io/gcs/files/b7bb2210dc0a798b8412d0a3d749e337.png?auto=format&w=3840"
       }
     },
@@ -323,7 +343,8 @@
       "name": "Old SW (dev)",
       "standard": "erc1155",
       "extensions": {
-        "blacklist": true
+        "blacklist": true,
+        "categories": ["gaming", "tcg", "skyweaver"]
       }
     },
     {
@@ -332,7 +353,8 @@
       "name": "Old SW (stg)",
       "standard": "erc1155",
       "extensions": {
-        "blacklist": true
+        "blacklist": true,
+        "categories": ["gaming", "tcg", "skyweaver"]
       }
     },
     {
@@ -345,6 +367,7 @@
       "extensions": {
         "link": "https://www.fintechfestival.sg/",
         "description": "Singapore Fintech Festival",
+        "categories": ["access", "rwa"],
         "ogImage": "https://assets.sequence.info/SFF/SFF_banner_d.png",
         "contractABIExtensions": ["PBM"]
       }
@@ -359,6 +382,7 @@
       "extensions": {
         "link": "https://www.fintechfestival.sg/",
         "description": "Singapore Fintech Festival",
+        "categories": ["access", "rwa"],
         "ogImage": "https://assets.sequence.info/SFF/SFF_banner_d.png",
         "contractABIExtensions": ["PBM"]
       }
@@ -373,6 +397,7 @@
       "extensions": {
         "link": "https://www.fintechfestival.sg/",
         "description": "Singapore Fintech Festival",
+        "categories": ["access", "rwa"],
         "ogImage": "https://assets.sequence.info/SFF/SFF_banner_d.png",
         "contractABIExtensions": ["PBM"]
       }
@@ -387,6 +412,7 @@
       "extensions": {
         "link": "https://www.temasek.com.sg/",
         "description": "Temasek",
+        "categories": ["access", "value", "rwa"],
         "ogImage": "https://assets.sequence.info/SFF/TCPM_banner.png",
         "contractABIExtensions": ["PBM"]
       }
@@ -401,6 +427,7 @@
       "extensions": {
         "link": "https://www.temasek.com.sg/",
         "description": "Temasek",
+        "categories": ["access", "value", "rwa"],
         "ogImage": "https://assets.sequence.info/SFF/TCPM_banner.png",
         "contractABIExtensions": ["PBM"]
       }
@@ -415,6 +442,7 @@
       "extensions": {
         "link": "https://gardens.shrub.finance/",
         "description": "The first interactive on-chain growth NFT. Shrub.finance's genesis NFT project is the most technically advanced NFT series yet. In this series you plant a seed and grow it into a Shrub all on the Polygon blockchain. Dynamic metadata means you watch it grow on OpenSea. Join us in this groundbreaking series. Seeds available here https://opensea.io/collection/shrub-paper-gardens-seeds.",
+        "categories": ["art", "simulation"],
         "ogImage": "https://i.seadn.io/gcs/files/ecd69e04d3f2c24ae950f78f87f5914f.png?auto=format&w=3840"
       }
     },
@@ -428,6 +456,7 @@
       "extensions": {
         "link": "https://www.cropbytes.com/",
         "description": "Welcome to CropBytes, where you can live the life of a virtual farmer and build your empire from the ground up! Own and run your business, engage in farming activities, and trade rare assets to grow your portfolio.",
+        "categories": ["gaming", "simulation", "strategy"],
         "ogImage": "https://i.seadn.io/gcs/files/fdc98308534c3c09171ee83f1f05844b.png?auto=format&w=3840",
         "featured": true
       }
@@ -444,6 +473,7 @@
       "extensions": {
         "link": "http://www.planetix.com",
         "description": "This is the collection for Planet IX Genesis Corporation NFTs. Players owning Genesis Corporation NFTs get exclusive access to airdrops and metashares in the respective in-game corporation. Owners will also enjoy exclusive benefits and utility to gain competitive advantage in the Planet IX ecosystem.\r\n\r\nPlanet IX Main Collection: https://opensea.io/collection/planet-ix",
+        "categories": ["gaming", "staking", "reward", "simulation", "strategy"],
         "ogImage": "",
         "originChainId": 0,
         "originAddress": "",
@@ -460,6 +490,7 @@
       "extensions": {
         "link": "https://metastar.gg/",
         "description": "This badge symbolizes your status as one of our most exclusive members. The crème de la crème. Expect exclusive rewards and special services to the owners of this sought out item.",
+        "categories": ["gaming", "sports", "action", "pvp"],
         "ogImage": "https://i.seadn.io/gcs/files/5983dfdfa8b8d30d4464299c8eb64552.png?auto=format&dpr=1&w=3840"
       }
     },
@@ -472,6 +503,7 @@
       "extensions": {
         "link": "https://www.cryptounicorns.fun/",
         "description": "Welcome to the Shadowcorns' spooky bazaar deep within the Dark Forest, which lies in the realms of Crypto Unicorns, a blockchain game where you can collect, hatch, and breed your own NFT Unicorns and Battle! The Shadowcorns, menacing cousins of Unicorns, use this market to purchase and sell their items, from Crafting Components to powerful Minions, ready to build their armies and launch an offensive against the unicorns!",
+        "categories": ["gaming", "access", "reward", "pvp"],
         "ogImage": "https://i.seadn.io/gcs/files/7de573fd08112f68f44c17ec91d49b54.png?auto=format&dpr=1&h=500"
       }
     },
@@ -484,6 +516,7 @@
       "extensions": {
         "link": "https://www.cryptounicorns.fun/",
         "description": "Crypto Unicorns is a blockchain game in which you can collect, hatch, breed, and evolve your very own Crypto Unicorns in order to participate in farming your Land NFTs, gathering resources, and joining in an ever-expanding list of activities like Jousting, Racing, and Team RPG Battle! So come on in and join the Unicorn Fam! Here you’ll be able to find a variety of items to help you in your journey... Lootboxes, Golden Tickets, the coveted Shadowcorn eggs, and more!",
+        "categories": ["gaming", "access", "reward", "pvp"],
         "ogImage": "https://i.seadn.io/gcs/files/7de573fd08112f68f44c17ec91d49b54.png?auto=format&dpr=1&h=500"
       }
     },
@@ -491,19 +524,37 @@
       "chainId": 137,
       "address": "0xd4D53d8D61adc3B8114C1cd17B89393640db9733",
       "name": "BoomLand - Artifacts",
-      "standard": "erc1155"
+      "standard": "erc1155",
+      "extensions": {
+        "link": null,
+        "description": null,
+        "categories": ["gaming", "access"],
+        "ogImage": null
+      }
     },
     {
       "chainId": 137,
       "address": "0x44b3f42e2BF34F62868Ff9e9dAb7C2F807ba97Cb",
       "name": "BoomLand - Shards",
-      "standard": "erc1155"
+      "standard": "erc1155",
+      "extensions": {
+        "link": null,
+        "description": null,
+        "categories": ["gaming", "access"],
+        "ogImage": null
+      }
     },
     {
       "chainId": 137,
       "address": "0x74d4567fd8B0b873B61FA180618a82183012F369",
       "name": "BoomLand - Equipments",
-      "standard": "erc1155"
+      "standard": "erc1155",
+      "extensions": {
+        "link": null,
+        "description": null,
+        "categories": ["gaming", "access"],
+        "ogImage": null
+      }
     },
     {
       "chainId": 137,
@@ -511,7 +562,8 @@
       "name": "$5000 BUSD Voucher",
       "standard": "erc1155",
       "extensions": {
-        "blacklist": true
+        "blacklist": true,
+        "categories": ["access", "value", "rwa"]
       }
     },
     {
@@ -520,7 +572,8 @@
       "name": "$5000 BUSD Voucher",
       "standard": "erc1155",
       "extensions": {
-        "blacklist": true
+        "blacklist": true,
+        "categories": ["access", "value", "rwa"]
       }
     },
     {
@@ -529,7 +582,8 @@
       "name": "Flore",
       "type": "erc1155",
       "extensions": {
-        "description": "Redeemable flower nfts, priced using dynamic off-chain weather data via ip lookup"
+        "description": "Redeemable flower nfts, priced using dynamic off-chain weather data via ip lookup",
+        "categories": ["art", "infrastructure"]
       }
     },
     {
@@ -539,7 +593,8 @@
       "type": "erc1155",
       "logoURI": "https://upload.wikimedia.org/wikipedia/en/thumb/b/bd/Reddit_Logo_Icon.svg/220px-Reddit_Logo_Icon.svg.png",
       "extensions": {
-        "description": "Collectible Avatars are limited-edition avatars from Reddit that provide owners with unique benefits on the Reddit platform. This Creator Collection was made by independent creators in partnership with Reddit. When you purchase a Collectible Avatar, you become the owner of it. This means you can keep it, trade it, sell it, or use it on Reddit as your avatar."
+        "description": "Collectible Avatars are limited-edition avatars from Reddit that provide owners with unique benefits on the Reddit platform. This Creator Collection was made by independent creators in partnership with Reddit. When you purchase a Collectible Avatar, you become the owner of it. This means you can keep it, trade it, sell it, or use it on Reddit as your avatar.",
+        "categories": ["art", "meme"]
       }
     },{
       "chainId": 137,
@@ -548,7 +603,8 @@
       "type": "erc1155",
       "logoURI": "https://chainplay.gg/_next/image/?url=https%3A%2F%2Ftk-storage.s3.ap-southeast-1.amazonaws.com%2Fhost%2Fgame%2FyjLb5bar_400x400_20221229105407.png&w=256&q=75",
       "extensions": {
-        "description": "Henlo! I'm a digital ghost trapped forever on the blockchain. Gaming helps distract me from my existential dread."
+        "description": "Henlo! I'm a digital ghost trapped forever on the blockchain. Gaming helps distract me from my existential dread.",
+        "categories": ["gaming", "mmo", "action", "simulation"]
       }
     },
     {
@@ -561,6 +617,7 @@
       "extensions": {
         "link": "https://www.synergyland.live/",
         "description": "Discover a wide array of valuable assets and artifacts in the Synergy Land Items collection. From powerful weapons to rare artifacts, these NFTs offer unique advantages and enhancements to aid you in your exploration and conquests throughout Synergy Land.",
+        "categories": ["gaming", "p2e", "action", "rpg"],
         "ogImage": "https://storage.googleapis.com/sequence-prod-cluster-builder/projects/1975/landingBannerUrl/d38b292d0c2370567154c94fbbbe982042c0950f76f7ee6932eac12a2831b80c.png"
       }
     },
@@ -574,6 +631,7 @@
       "extensions": {
         "link": "https://www.synergyland.live/",
         "description": "These Islands form the backbone of Synergy Land's world, featuring three tiers, each with unique characteristics and rarities. They serve as the foundation for our Play, Rent & Earn model, which incorporates the renting feature. We merged these three elements to grant players access to the in-game economy.",
+        "categories": ["gaming", "p2e", "action", "rpg"],
         "ogImage": "https://storage.googleapis.com/sequence-prod-cluster-builder/projects/1958/9ce5ab1ffd6bcc43056d9052a9aa95690bccffe237dab855ce8f977df2f78c80.png"
       }
     },
@@ -587,6 +645,7 @@
       "extensions": {
         "link": "https://boomland.io",
         "description": "BoomLand, the creator of Hunters On-Chain, is a leading game developer & publisher, providing Mass Adoption of high-quality Web3 games on Polygon to a broader audience of traditional gamers. This is the Ticket's NFT, which allows players to enter specific game modes",
+        "categories": ["gaming", "access"],
         "ogImage": "https://www.boomland.io/static/media/homeThumbnail.37e22084c408bc384b17.jpg"
       }
     }  

--- a/index/polygon/erc20.json
+++ b/index/polygon/erc20.json
@@ -5500,7 +5500,7 @@
       "name": "Old Test Dai (dev)",
       "extensions": {
         "blacklist": true
-        "categories": ["usd-stablecoin", "transactional", "defi", "maker"],
+        "categories": ["usd-stablecoin", "transactional", "defi", "maker"]
       }
     },
     {

--- a/index/polygon/erc20.json
+++ b/index/polygon/erc20.json
@@ -1073,6 +1073,7 @@
         "link": "https://allianceblock.io/",
         "description": null,
         "ogImage": "https://allianceblock.io/wp-content/uploads/2020/10/hero-image.png",
+        "categories": ["defi", "infrastructure", "governance"],
         "originChainId": 1,
         "originAddress": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0"
       }
@@ -1087,6 +1088,7 @@
       "extensions": {
         "link": "https://www.taconomics.io",
         "description": null,
+        "categories": ["meme"],
         "ogImage": "https://uploads-ssl.webflow.com/5f25b95c4e0af7c62817409b/5f2af9523b851f2b4abb3adf_Gender_Fluid_Taco.png",
         "originChainId": 1,
         "originAddress": "0x00d1793d7c3aae506257ba985b34c76aaf642557"
@@ -1102,6 +1104,7 @@
       "extensions": {
         "link": "https://unilend.finance/",
         "description": "UniLend is a permission-less DeFi protocol that combines spot trading services and lending/borrowing functionality within the same platform. Whereas current DeFi protocols support only ~30 assets, anyone can list any ERC20 asset on UniLend for decentralized trading and lending/borrowing. UFT token is UniLend's native governance token; holders of UFT can create proposals for, and vote on, a number of factors relating to the functioning of the protocol.",
+        "categories": ["defi", "lending", "exchange", "protocol"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1"
@@ -1117,6 +1120,7 @@
       "extensions": {
         "link": "https://www.orionprotocol.io/",
         "description": "Orion is a DeFi platform providing B2B + B2C solutions for liquidity. It aims to solve the the largest problems in DeFi by aggregating the liquidity of the entire crypto market into one decentralized platform – pulling from every major centralized exchange, decentralized exchange, and swapping pool. ",
+        "categories": ["exchange", "defi", "protocol", "access", "infrastructure"],
         "ogImage": "https://www.orionprotocol.io/hubfs/Screen%20Shot%202020-05-27%20at%209.49.21%20AM.png#keepProtocol",
         "originChainId": 1,
         "originAddress": "0x0258f474786ddfd37abce6df6bbb1dd5dfc4434a"
@@ -1132,6 +1136,7 @@
       "extensions": {
         "link": "https://pteria.org/",
         "description": null,
+        "categories": ["governance", "access"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x02eca910cb3a7d43ebc7e8028652ed5c6b70259b"
@@ -1147,6 +1152,7 @@
       "extensions": {
         "link": "https://cntr.finance/",
         "description": null,
+        "categories": ["defi"],
         "ogImage": "https://cntr.finance/img/favicon.png",
         "originChainId": 1,
         "originAddress": "0x03042482d64577a7bdb282260e2ea4c8a89c064b"
@@ -1162,6 +1168,7 @@
       "extensions": {
         "link": "http://btc.piedao.org",
         "description": "BTC++ it’s a weighed allocation between the different representations of Bitcoin on the Ethereum",
+        "categories": ["defi", "value", "protocol"],
         "ogImage": "./assets/preview.png",
         "originChainId": 1,
         "originAddress": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd"
@@ -1177,6 +1184,7 @@
       "extensions": {
         "link": "https://0xmonero.com/",
         "description": "0xMR is a mineable privacy token on the Ethereum blockchain",
+        "categories": ["privacy", "value", "infrastructure"],
         "ogImage": "https://img1.wsimg.com/isteam/ip/f1512585-2929-446d-973e-2c29ee3cfd4f/2_5366053052094613395.png",
         "originChainId": 1,
         "originAddress": "0x035df12e0f3ac6671126525f1015e47d79dfeddf"
@@ -1192,6 +1200,7 @@
       "extensions": {
         "link": "https://www.LCX.com",
         "description": "LCX, the Liechtenstein Cryptoassets Exchange, aims to become one of the world’s first licensed and supervised security token exchanges.\r\n\r\nThe initial product is LCX Terminal, a crypto trading desk to trade on major crypto exchanges within a single interface. In November 2018, LCX claims to have been granted a Business License of the Liechtenstein Ministry of Economic Affairs.\r\n\r\nLCX AG was found in April 2018 and is headquartered at the Principality of Liechtenstein.",
+        "categories": ["exchange", "infrastructure", "protocol"],
         "ogImage": "https://www.lcx.com/wp-content/uploads/LCX-Home-Index-Image.png",
         "originChainId": 1,
         "originAddress": "0x037a54aab062628c9bbae1fdb1583c195585fe41"
@@ -1207,6 +1216,7 @@
       "extensions": {
         "link": "https://glitch.finance/",
         "description": "Glitch is a blockchain agnostic super protocol, purpose-built to facilitate trust-less money markets.",
+        "categories": ["defi", "protocol", "infrastructure"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x038a68ff68c393373ec894015816e33ad41bd564"
@@ -1223,6 +1233,7 @@
         "link": "https://barnbridge.com/",
         "description": "A Cross Platform Protocol for Tokenizing Risk.",
         "ogImage": "https://barnbridge.com/wp-content/uploads/2020/11/bb.png",
+        "categories": ["governance", "defi", "protocol", "staking", "reward"],
         "originChainId": 1,
         "originAddress": "0x0391d2021f89dc339f60fff84546ea23e337750f"
       }
@@ -1237,6 +1248,7 @@
       "extensions": {
         "link": "https://www.lid.sh",
         "description": "Licensed Proof of Locked Liquidity solutions for pre-sales and DEX launches.",
+        "categories": ["defi", "protocol", "liquidity"],
         "ogImage": "/static/opengraph.png",
         "originChainId": 1,
         "originAddress": "0x0417912b3a7af768051765040a55bb0925d4ddcf"
@@ -1252,6 +1264,7 @@
       "extensions": {
         "link": "https://unilock.network",
         "description": "Unilock is introduced to the universe of cryptocurrencies to help legitimate projects evolve and grow. We are one of a kind.",
+        "categories": ["protocol", "defi", "smart-contract"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x04ab43d32d0172c76f5287b6619f0aa50af89303"
@@ -1267,6 +1280,7 @@
       "extensions": {
         "link": "https://unifund.global/",
         "description": "Unifund is a layer 2 system on Uniswap enabling the creation of trustless managed trading groups wish customizable risk profiles",
+        "categories": ["defi", "protocol", "exchange"]
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x04b5e13000c6e9a3255dc057091f3e3eeee7b0f0"
@@ -1282,6 +1296,7 @@
       "extensions": {
         "link": "https://umaproject.org",
         "description": "UMA is a decentralized financial contracts platform built to enable Universal Market Access.\r\n\r\nUMA builds infrastructure for “priceless” financial contracts: DeFi contracts that minimize oracle usage, avoiding many of the security and scalability issues that have plagued decentralized finance. The first contracts built with UMA are priceless synthetic tokens: ERC20 tokens that can track anything while minimizing the need for on-chain price data.\r\n\r\nThe UMA project token powers the system in two ways:\r\n\r\nGovernance: UMA token holders govern what types of contracts can access the system, which asset types are supported, and key system parameters and upgrades.\r\n\r\nPrice requests: the priceless methodology minimizes on-chain price requests but doesn’t eliminate them — when contract interactions are disputed, UMA token holders fulfill price requests via the Data Verification Mechanism, or DVM.\r\n\r\nUMA tokens enable the holder to participate in community governance and resolve contract dis...",
+        "categories": ["defi", "protocol", "governance", "smart-contract", "infrastructure"],
         "ogImage": "https://umaproject.org/assets/images/UMA_square_red_logo.png",
         "originChainId": 1,
         "originAddress": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828"
@@ -1297,6 +1312,7 @@
       "extensions": {
         "link": "https://bitsong.io/en",
         "description": "BitSong is a distributed (open source) blockchain music ecosystem born in December 2017, to create a decentralized and trustless hub that interconnects the various market players.\r\n\r\nOur mission is to decentralize the music sector by simplifying the bureaucracy as much as possible in order to offer artists a meritocratic, transparent, fast and intermediary-free earning model and users a new way to listen to music and earn money.\r\n\r\nBitSong is not a streaming platform but a real decentralized ecosystem of services and an active community of artists, music providers and fans (listeners) that aims to become the only point of reference within the digital music market.\r\n\r\n\r\n",
+        "categories": ["music", "access", "reward"],
         "ogImage": "/social-share.png",
         "originChainId": 1,
         "originAddress": "0x05079687d35b93538cbd59fe5596380cae9054a9"
@@ -1312,6 +1328,7 @@
       "extensions": {
         "link": "https://plasma.finance",
         "description": "Plasma.Finance is a cross-chain DeFi aggregator and portfolio management platform.",
+        "categories": ["defi", "protocol", "infrastructure"],
         "ogImage": "https://uploads-ssl.webflow.com/5fb23ed0d183e443d48de300/5fd13f4854277e2261f2820c_meta-pfi-site.png",
         "originChainId": 1,
         "originAddress": "0x054d64b73d3d8a21af3d764efd76bcaa774f3bb2"
@@ -1327,6 +1344,7 @@
       "extensions": {
         "link": "https://gemini.com/dollar/",
         "description": "The Gemini dollar — the world’s first regulated stablecoin — combines the creditworthiness and price stability of the U.S. dollar with blockchain technology and the oversight of U.S. regulators.\r\n\r\nGet Gemini dollars 1-to-1 for U.S. dollars on Gemini.\r\nGemini dollars can be used on the Ethereum network.\r\n\r\nISSUER\r\nThe Gemini dollar is issued by Gemini Trust Company, LLC, a New York trust company.\r\n\r\nBANK\r\nU.S. dollars that correspond to the Gemini dollars issued and in circulation are held at a U.S. bank and eligible for FDIC “pass-through” deposit insurance, subject to applicable limitations.\r\n\r\nEXAMINATION\r\nThe U.S. dollar deposit balance is examined monthly by an independent registered public accounting firm to verify the 1:1 peg. All Independent Accountants’ Reports are published and available <a href=\"https://gemini.com/dollar/#reports\">here</a>.\r\n\r\nSECURITY AUDIT\r\nThe Gemini dollar is a cryptographic token built on the Ethereum Network according to the ERC20 standard for token...",
+        "categories": ["usd-stablecoin", "transactional"],
         "ogImage": "https://www.gemini.com/static/images/og.png",
         "originChainId": 1,
         "originAddress": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd"
@@ -1342,6 +1360,7 @@
       "extensions": {
         "link": "https://sakeswap.finance/",
         "description": "SakeSwap, a profitable DEX, captures slippage and increases~50% of transaction fee income.",
+        "categories": ["defi", "exchange", "protocol"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x066798d9ef0833ccc719076dab77199ecbd178b0"
@@ -1357,6 +1376,7 @@
       "extensions": {
         "link": "https://smartkeyplatform.io/",
         "description": null,
+        "categories": ["infrastructure", "smart-contract", "protocol"],
         "ogImage": "https://smartkeyplatform.io/og-logo.png",
         "originChainId": 1,
         "originAddress": "0x06a01a4d579479dd5d884ebf61a31727a3d8d442"
@@ -1372,6 +1392,7 @@
       "extensions": {
         "link": "https://chai.money/",
         "description": "Accrue interest on your Dai by turning it into Chai.",
+        "categories": ["defi", "reward"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x06af07097c9eeb7fd685c692751d5c66db49c215"
@@ -1387,6 +1408,7 @@
       "extensions": {
         "link": "https://masq.ai",
         "description": "MASQ Network is a decentralized mesh networking software that is censorship-resistant, without the need for using a VPN or Tor. It incentivizes all users to utilize their spare bandwidth and allows trustless connections across the globe to share internet freedom on the clear web",
+        "categories": ["infrastructure", "protocol", "privacy"],
         "ogImage": "http://static1.squarespace.com/static/5ddadf8b61672b4797e56d44/t/5f529d15c4b3656b36737217/1599249688244/MASQ_Logo_Gold.png?format=1500w",
         "originChainId": 1,
         "originAddress": "0x06f3c323f0238c72bf35011071f2b5b7f43a054c"
@@ -1402,6 +1424,7 @@
       "extensions": {
         "link": "https://www.baseprotocol.org/",
         "description": "Base Protocol (BASE) is a token whose price is pegged to the total market cap of all cryptocurrencies at a ratio of 1 : 1 trillion. BASE allows traders to speculate on the entire crypto industry with one token. If crypto market cap is $450B, BASE is $0.45. If crypto market cap is $800B, BASE is $0.80.",
+        "categories": ["protocol", "value", "layer2", "chain", "smart-contract"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x07150e919b4de5fd6a63de1f9384828396f25fdc"
@@ -1417,6 +1440,7 @@
       "extensions": {
         "link": "https://www.uptrennd.com/",
         "description": "Uptrennd stands on four foundational pillars: Freedom of Speech, Data Security, Equality of Opportunity and Distribution of Wealth.\r\n\r\nOn Uptrennd, your private information will never permisionlessly be sold, and you will earn ~80% of all profits generated on the platform.\r\nUptrennd is a movement to shift the wealth and power from the corporations, back to the people.\r\n\r\nBloggers, photographers, videographers, musicians, podcasters, selfie-aficionados, and all other content creators are now able\r\nto monetize and thrive through their posts and passions like never before.\r\n\r\nEvery time a member’s post or comment is upvoted, they receive rewards. The higher a members level, the more rewards they can earn.\r\nAt level one, members earn one token per upvote. Each token on the platform is sold at a base rate of $0.05.\r\nUpvoting is free.\r\n\r\nDuring the initial growth phase of Uptrennd, the conversation will be focused on the niche of cryptocurrency.\r\nAs the community grows, (6months-1yr) topi...",
+        "categories": ["social", "reward", "governance", "privacy"],
         "ogImage": "https://www.uptrennd.com/images/sharings.jpg",
         "originChainId": 1,
         "originAddress": "0x07597255910a51509ca469568b048f2597e72504"
@@ -1432,6 +1456,7 @@
       "extensions": {
         "link": "https://social-rocket.co/",
         "description": "Social Rocket empowers Twitter & Telegram communities with taylor-made crypto features & blockchain technologies.\r\n",
+        "categories": ["access", "infrastructure"],
         "ogImage": "https://social-rocket.co/wp-content/uploads/2020/11/homepage-preview.png",
         "originChainId": 1,
         "originAddress": "0x0829d2d5cc09d3d341e813c821b0cfae272d9fb2"
@@ -1447,6 +1472,7 @@
       "extensions": {
         "link": "https://www.dentacoin.com/",
         "description": "Dentacoin is an <a href=\"https://www.coingecko.com/en/coins/ethereum\">Ethereum</a>-based blockchain platform regulated by smart contracts. The platform supports the dental community by building and creating solutions devoted to improving the quality of dental care worldwide. The blockchain gives Dentacoin the power to change the world for the better. Dentacoin develops the dental industry as well as creates market intelligence through a cryptocurrency reward system that inspires participation throughout the community.\r\n\r\nDentacoin is the first cryptocurrency that uses a decentralized review platform and transparently rewards patients and dentists who make contributions that benefit the community. The Dentacoin Foundation team strongly believes in building a future healthcare industry that will fall into the hands of the people, resulting in the disruption of the existing industries and the creation of new industries in the short and long term.\r\n\r\nDentacoin strives to create a dental...",
+        "categories": ["transactional", "infrastructure", "rwa"],
         "ogImage": "https://dentacoin.com/assets/uploads/dcn-fb-thumb.png",
         "originChainId": 1,
         "originAddress": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6"
@@ -1462,6 +1488,7 @@
       "extensions": {
         "link": "https://mathwallet.org/",
         "description": "MATH is a one stop crypto solution platform which contains MathWallet, MATH VPOS Pool, MathDEX, MATH dApp Store, MATH Staking, MATH Pay, MATH Chain, etc.",
+        "categories": ["defi", "infrastructure", "protocol", "access"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30"
@@ -1477,6 +1504,7 @@
       "extensions": {
         "link": "https://www.indexcoop.com/",
         "description": null,
+        "categories": ["defi", "protocol", "governance"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x0954906da0bf32d5479e25f46056d22f08464cab"
@@ -1492,6 +1520,7 @@
       "extensions": {
         "link": "https://shardus.com/",
         "description": "Shardus is building distributed ledger software to remedy the problems of traditional blockchains -- scalability, decentralization and efficiency. The technology being developed will use compute and state sharding to accommodate billions of daily active users, allowing for global-scale decentralized networks.",
+        "categories": ["infrastructure", "protocol", "smart-contract"],
         "ogImage": "https://shardus.com/assets/img/shardus-thumb-04-2019-1-91.png",
         "originChainId": 1,
         "originAddress": "0x09617f6fd6cf8a71278ec86e23bbab29c04353a7"
@@ -1507,6 +1536,7 @@
       "extensions": {
         "link": "https://mirror.finance",
         "description": "What are Mirrored Assets?\r\nMIR is the governance token of Mirror Protocol, a synthetic assets protocol built by Terraform Labs (TFL) on the Terra blockchain.\r\n\r\nMirror Protocol is decentralized from day 1, with the on-chain treasury and code changes governed by holders of the MIR token. TFL has no intention of keeping or selling MIR tokens, and there are no admin keys or special access privileges granted. The intent for this is to be a completely decentralized, community-driven project.\r\n\r\nMirrored assets are blockchain tokens that behave like \"\"mirror\"\" versions of real-world assets by reflecting the exchange prices on-chain. They give traders the price exposure to real assets while enabling fractional ownership, open access and censorship resistance as any other cryptocurrency. Unlike traditional tokens which serve to represent a real, underlying asset, mAssets are purely synthetic and only capture the price movement of the corresponding asset.",
+        "categories": ["defi", "protocol", "governance"],
         "ogImage": "https://mirror.finance/assets/img/meta_image.png",
         "originChainId": 1,
         "originAddress": "0x09a3ecafa817268f77be1283176b946c4ff2e608"
@@ -1522,6 +1552,7 @@
       "extensions": {
         "link": "https://dos.network/",
         "description": "DOS Network - A Decentralized Oracle Service supporting multiple heterogeneous blockchains. DOS Network brings real word data, event and computation power to smart contract in a secure, reliable, efficient and scalable way.",
+        "categories": ["infrastructure", "protocol", "access"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x0a913bead80f321e7ac35285ee10d9d922659cb7"
@@ -1537,6 +1568,7 @@
       "extensions": {
         "link": "https://yam.finance/",
         "description": null,
+        "categories": ["defi", "governance", "protocol"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x0aacfbec6a24756c20d41914f2caba817c0d8521"
@@ -1552,6 +1584,7 @@
       "extensions": {
         "link": "https://www.xdaichain.com",
         "description": "STAKE is a new ERC20-type (implemented as an ERC677) token designed to secure the on-chain payment layer and provide a mechanism for validators to receive multiple POS incentives. It is an ERC20-based staking token with a market driven value. ",
+        "categories": ["protocol", "staking", "reward", "governance"],
         "ogImage": "https://app.gitbook.com/share/space/thumbnail/-Lpi9AHj62wscNlQjI-l.png",
         "originChainId": 1,
         "originAddress": "0x0ae055097c6d159879521c384f1d2123d1f195e6"
@@ -1567,6 +1600,7 @@
       "extensions": {
         "link": "https://polybius.io/",
         "description": "Polybius Bank project will operate on the principles of an Open API, employing reputable innovations and services within the framework of payment and data processing industry. The activities of the Polybius will be developed on an incremental basis investing the capital according to the development of the customer base and with the objective of maximizing the capital versus revenues ratio. By providing the infrastructure for system-to-system communications, Polybius Foundation will act as a Trustee service and will be responsible for the control and execution of compliance-related directives.",
+        "categories": ["infrastructure", "transactional", "protocol"],
         "ogImage": "https://polybius.io/app/uploads/2019/02/sharing.jpg",
         "originChainId": 1,
         "originAddress": "0x0affa06e7fbe5bc9a764c979aa66e8256a631f02"
@@ -1582,6 +1616,7 @@
       "extensions": {
         "link": "https://api3.org/",
         "description": "API3 builds blockchain-native, decentralized APIs with DAO-governance and quantifiable security.",
+        "categories": ["infrastructure", "protocol", "access", "governance"],
         "ogImage": "https://api3.org/img/favicons/API3.png",
         "originChainId": 1,
         "originAddress": "0x0b38210ea11411557c13457d4da7dc6ea731b88a"
@@ -1597,6 +1632,7 @@
       "extensions": {
         "link": "https://streamr.network/",
         "description": "Streamr tokenizes streaming data to enable a new way for machines & people to trade it on a decentralised P2P network.",
+        "categories": ["infrastructure", "protocol", "access"],
         "ogImage": "https://streamr.network/resources/social/public-site.png",
         "originChainId": 1,
         "originAddress": "0x0cf0ee63788a0849fe5297f3407f701e122cc023"
@@ -1612,6 +1648,7 @@
       "extensions": {
         "link": "https://nexusmutual.io/",
         "description": "NXM token itself is created solely for internal use within the Nexus Mutual protocol and all of its holders must go through KYC. As such, a wrapped version is created to allow more users to own the token without having to do KYC. In the meantime it also improves its liquidity outside the protocol’s bonding curve by being listed on exchanges such as Uniswap and Binance. \r\n\r\nTo make use of the wNXM token, it first needs to be unwrapped into NXM by a registered member of Nexus Mutual. After it is unwrapped, wNXM becomes NXM and can be used as a normal token on the Nexus Mutual platform. ",
+        "categories": ["wrapped", "defi", "access"],
         "ogImage": "https://www.nexusmutual.io/assets/img/nxm-favicon-152x152.png",
         "originChainId": 1,
         "originAddress": "0x0d438f3b5175bebc262bf23753c1e53d03432bde"
@@ -1627,6 +1664,7 @@
       "extensions": {
         "link": "https://basicattentiontoken.org/",
         "description": "Basic Attention Token (BAT) is an open-source, decentralized ad exchange platform built on <a href=\"https://www.coingecko.com/en/coins/ethereum\">Ethereum</a> platform. Basic Attention Token held an initial coin offering on May 31, 2017 for its eponymous ERC-20 utility token, raising approximately $35M USD at the time in less than 30 seconds. The Basic Attention Token aims to fix digital advertising, which is broken, fraudulent and opaque. \r\n\r\nBasic Attention Token work by having advertisers pay BAT to website publishers for the attention of users. The BAT token is designed to correctly value and price user attention within the platform. The Basic Attention Token comprises various components, including attention measurement systems, analytics dashboards and machine learning algorithms. Integration of BAT into a given host application involves implementing BAT Ads, a system that matches and displays ads to users based on locally stored data. Ad targeting is performed wholly on-device,...",
+        "categories": ["infrastructure", "reward", "transactional", "access"],
         "ogImage": "https://basicattentiontoken.org/static-assets/images/bat-og.png",
         "originChainId": 1,
         "originAddress": "0x0d8775f648430679a709e98d2b0cb6250d2887ef"
@@ -1642,6 +1680,7 @@
       "extensions": {
         "link": "https://hakka.finance/",
         "description": null,
+        "categories": ["defi", "protocol", "governance"],
         "ogImage": "/img/og-image.png",
         "originChainId": 1,
         "originAddress": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd"
@@ -1657,6 +1696,7 @@
       "extensions": {
         "link": "https://blockzerolabs.io",
         "description": "We are Blockzero Labs, a blockchain startup network focused on launching innovative, original, and experimental ideas into the decentralized world.",
+        "categories": ["defi", "protocol", "infrastructure"],
         "ogImage": "https://blockzerolabs.io/wp-content/uploads/2020/12/Untitled-design8.png",
         "originChainId": 1,
         "originAddress": "0x0f7f961648ae6db43c75663ac7e5414eb79b5704"
@@ -1672,6 +1712,7 @@
       "extensions": {
         "link": "https://unilayer.app/",
         "description": "UniLayer is a new generation decentralised trading platform built on top of Uniswap that enables key features for professional-level trading with its LAYER utility token, focusing on automated swaps and liquidity management, flash staking, charts and analytics, live order books, and a lot more.",
+        "categories": ["defi", "exchange", "protocol"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x0ff6ffcfda92c53f615a4a75d982f399c989366b"
@@ -1687,6 +1728,7 @@
       "extensions": {
         "link": "https://unimex.network/",
         "description": "UniMex is an innovative onchain margin-trading platform entirely contained within Uniswap. Which means that shorts/longs are directly executed on Uniswap, rather than through an offchain approach e.g. through a 0x relayer. Margin traders are charged fees which are disbursed to lenders as a reward for supplying liquidity to lending pools.",
+        "categories": ["defi", "exchange", "protocol"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x10be9a8dae441d276a5027936c3aaded2d82bc15"
@@ -1702,6 +1744,7 @@
       "extensions": {
         "link": "https://1inch.exchange/",
         "description": null,
+        "categories": ["defi", "exchange", "protocol", "governance"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x111111111117dc0aa78b770fa6a738034120c302"
@@ -1717,6 +1760,7 @@
       "extensions": {
         "link": "https://ygy.finance/",
         "description": "Main Governance and Access Token to Generation of Yield",
+        "categories": ["defi", "protocol", "reward"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x11b0a8c0fa626627601ed518c3538a39d92d609e"
@@ -1732,6 +1776,7 @@
       "extensions": {
         "link": "https://www.layer1crypto.com/",
         "description": "Layer1 is the first tokenized content network, powered by the social utility token $LADZ.",
+        "categories": ["access", "infrastructure"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x1287c0509df9a475ef178471ab2132b9dfd312b3"
@@ -1747,6 +1792,7 @@
       "extensions": {
         "link": "https://vox.finance",
         "description": "Vox.Finance is an innovative DeFi project created by independent developers that seeks to revolutionize the market by providing a community-led approach.",
+        "categories": ["defi", "protocol", "governance"],
         "ogImage": "/images/logoIcon.png",
         "originChainId": 1,
         "originAddress": "0x12d102f06da35cc0111eb58017fd2cd28537d0e1"
@@ -1762,6 +1808,7 @@
       "extensions": {
         "link": "http://www.hyprr.com/",
         "description": "Howdoo is a revolutionary new messaging and social media platform that offers greater choice and control to users. Designed to encourage a more open and decentralized approach to mass social networking, it’s a platform that gives people full command over their personal data. It’s about incentivizing participation and contribution; allowing this value to flow freely across the network; enabling users to select for themselves the content they want to engage with; and inspiring a fairer, more community-driven form of moderation.",
+        "categories": ["access", "privacy", "infrastructure"],
         "ogImage": "https://hyprr.com/static/assets/images/LogoMeta.png",
         "originChainId": 1,
         "originAddress": "0x12f649a9e821f90bb143089a6e56846945892ffb"
@@ -1777,6 +1824,7 @@
       "extensions": {
         "link": "https://armor.fi",
         "description": null,
+        "categories": ["defi", "access", "protocol"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x1337def16f9b486faed0293eb623dc8395dfe46a"
@@ -1793,6 +1841,7 @@
         "link": "https://unit.xyz/",
         "description": null,
         "ogImage": "https://d3n32ilufxuvd1.cloudfront.net/5ef3621e65b4b6006f2b9e0b/2022978/screenshot-a1ba8b3d-d386-4ed8-8d0f-e00cd44e578e_readyscr_1024.jpg",
+        "categories": ["usd-stablecoin", "stablecoin", "transactional"],
         "originChainId": 1,
         "originAddress": "0x1456688345527be1f37e9e627da0837d6f08c925"
       }
@@ -1807,6 +1856,7 @@
       "extensions": {
         "link": "https://geodb.com/",
         "description": "GeoDB is a decentralized peer-to-peer big data sharing ecosystem, which returns value to its creators, the users. GeoDB’s mission is to democratize the 260bn Big Data industry, building an open ecosystem in which to establish better and trusted relationships between market participants while giving back control and value to data generators, the users. GeoDB is using blockchain technology to eliminate intermediation in a huge industry and allow a faster growth an adoption.\r\n\r\n",
+        "categories": ["infrastructure", "protocol", "reward"],
         "ogImage": "https://geodb.com/images/geodb_og.png",
         "originChainId": 1,
         "originAddress": "0x147faf8de9d8d8daae129b187f0d02d819126750"
@@ -1822,6 +1872,7 @@
       "extensions": {
         "link": "https://www.tokensets.com/portfolio/dpi",
         "description": "A basket created by DeFiPulse of the top DeFi tokens by market cap. The DPI Set is rebalanced monthly to realign to its market cap weighted index. Buy into the top DeFi tokens by buying the DeFiPulse Index Set.",
+        "categories": ["defi", "protocol", "value"],
         "ogImage": "https://s3.amazonaws.com/set-core/img/assets/opengraph.png",
         "originChainId": 1,
         "originAddress": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b"
@@ -1837,6 +1888,7 @@
       "extensions": {
         "link": "https://gala.games/",
         "description": "GALA is designed to power the Gala Games ecosystem to support gaming re-imagined to benefit creators and players, alike.",
+        "categories": ["gaming", "infrastructure", "reward"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x15d4c048f83bd7e37d49ea4c83a07267ec4203da"
@@ -1852,6 +1904,7 @@
       "extensions": {
         "link": "https://300.army/",
         "description": "Spartan token [300] is an experimental token, it aims to be a store of value, that is why the total supply its only 300. You will be able to buy our NFTs with 300 in the future. With NFT's you will get upgraded on discord and gain access to a curtain chats and gain a salary paid in Iron Bars, the currency used on Discord, we will have a city, a play role on discord.",
+        "categories": ["value", "access"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x167e2a574669b0eeb552aaf3da47c728cb348a41"
@@ -1867,6 +1920,7 @@
       "extensions": {
         "link": "https://erasure.world/",
         "description": "A new kind of hedge fund built by a network of data scientists.",
+        "categories": ["infrastructure", "protocol", "defi"],
         "ogImage": "https://erasure.world/static/media/crowdsourcing.3d3bcd63.jpg",
         "originChainId": 1,
         "originAddress": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671"
@@ -1882,6 +1936,7 @@
       "extensions": {
         "link": "https://www.kitten.finance/",
         "description": null,
+        "categories": ["defi", "protocol"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x177ba0cac51bfc7ea24bad39d81dcefd59d74faa"
@@ -1897,6 +1952,7 @@
       "extensions": {
         "link": "https://indexed.finance",
         "description": "CC10 is a passively managed, capitalization-weighted index that tracks the top 10 tokens by market cap from the Cryptocurrency market sector defined by NDX governance. It uses a high-fee AMM to rebalance gradually toward portfolio targets, which are set by a smart contract using price data from Uniswap.",
+        "categories": ["defi", "protocol", "value"],
         "ogImage": "https://i.imgur.com/TfkmJWJ.png",
         "originChainId": 1,
         "originAddress": "0x17ac188e09a7890a1844e5e65471fe8b0ccfadf3"
@@ -1912,6 +1968,7 @@
       "extensions": {
         "link": "https://audius.co/",
         "description": "AUDIO is the native platform token of the Audius streaming protocol. AUDIO is staked for security, feature access and governance and earned by artists, fans and node operators who drive Audius.",
+        "categories": ["access", "governance", "infrastructure", "staking", "reward", "music"],
         "ogImage": "/ogImage.jpg",
         "originChainId": 1,
         "originAddress": "0x18aaa7115705e8be94bffebde57af9bfc265b998"
@@ -1927,6 +1984,7 @@
       "extensions": {
         "link": "https://reserve.org/",
         "description": "Reserve aims to build a stable, decentralized, asset-backed cryptocurrency and a digital payment system that scales supply with demand and maintains 100% or more collateral backing. Ultimately, Reserve’s goal is to create a universal store of value – particularly in regions with unreliable banking infrastructure and regions where hyperinflation is an issue. The Reserve system will interact with three kinds of tokens: \r\n\r\n(1) The Reserve token (RSV), which is a stable cryptocurrency that can be held and spent the way we use normal fiat money; \r\n\r\n(2) The Reserve Rights token (RSR), a protocol token used to facilitate the stability of RSV.\r\n\r\n(3) A growing variety of tokenized real-world assets (such as other stablecoins) that are held by the Reserve smart contract to back RSV. ",
+        "categories": ["stablecoin", "value", "protocol"],
         "ogImage": "https://assets.website-files.com/5c0651c367dd7b1992d59e02/5c0f6da6300e0bb450771327_reserve-thumbnail.png",
         "originChainId": 1,
         "originAddress": "0x196f4727526ea7fb1e17b2071b3d8eaa38486988"
@@ -1941,6 +1999,7 @@
       "logoURI": "https://assets.coingecko.com/coins/images/8824/large/usdk.png?1563418517",
       "extensions": {
         "link": "https://www.oklink.com/",
+        "categories": ["usd-stablecoin", "stablecoin", "transactional"],
         "description": null,
         "ogImage": null,
         "originChainId": 1,
@@ -1957,6 +2016,7 @@
       "extensions": {
         "link": "https://renproject.io/",
         "description": "REN Tokenized ZEC\r\n\r\nOnce an asset is in the custody of RenVM, an ERC20 token at a 1:1 value is minted on Ethereum - this can then be used as any ERC20 can within the Ethereum ecosystem (for example, swaps, collateralization, trades etc.)",
+        "categories": ["wrapped", "value", "rwa"],
         "ogImage": "/share.jpg",
         "originChainId": 1,
         "originAddress": "0x1c5db575e2ff833e46a2e9864c22f4b22e0b37c2"
@@ -1972,6 +2032,7 @@
       "extensions": {
         "link": "https://nfy.finance/",
         "description": "Non-Fungible Yearn is a DeFi platform whose goal is to utilize the full potential of Non-Fungible Tokens (NFTs) in the DeFi sector.",
+        "categories": ["defi", "art", "access"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x1cbb83ebcd552d5ebf8131ef8c9cd9d9bab342bc"
@@ -1987,6 +2048,7 @@
       "extensions": {
         "link": "https://chartex.pro/",
         "description": "ChartEx is a leading provider of full Candlestick charting for markets on Uniswap, the largest Decentralized Exchange running on the Ethereum Network.",
+        "categories": ["infrastructure", "access", "defi"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x1d37986f252d0e349522ea6c3b98cb935495e63e"
@@ -2001,6 +2063,7 @@
       "logoURI": "https://assets.coingecko.com/coins/images/12302/large/VBa2Z60o_400x400.png?1598982471",
       "extensions": {
         "link": "https://kimchi.finance/",
+        "categories": ["defi", "protocol"],
         "description": null,
         "ogImage": null,
         "originChainId": 1,
@@ -2017,6 +2080,7 @@
       "extensions": {
         "link": "https://vndc.io/",
         "description": "\"VNDC is a stablecoin of Vietnam Dong on the blockchain smart contract system, pegged to VND by the rate of 1:1, so that the price of digital currency assets could be stabilised. It is supported by sufficient cash and equivalent assets. VNDC is a stable digital currency system that is based on the ERC20 standard of Ethereum platform and BEP2 standard of Binance platform.\r\nOur vision is becoming a stable coin for Vietnamese community, backed by sufficient assets, and always on par with Vietnam Dong on 1:1 exchange rate. VNDC is not only a stable coin but as well as gateway supporting users to convert their fiat money to stable coin (and vise versa), in line with the global blockchain movements.\r\nVNDC is the first stable coin of Vietnam, and the first Stablecoin that offer staking at 12% annual rate. This system then can be utilised as a mechanism for trading and hedging in global crypto capital markets, as well as, preparation for the upcoming global stablecoin movements.\r\nVNDC consi...",
+        "categories": ["stablecoin", "transactional"],
         "ogImage": "https://vndc.io/wp-content/uploads/2020/05/feature-image.png",
         "originChainId": 1,
         "originAddress": "0x1f3f677ecc58f6a1f9e2cf410df4776a8546b5de"
@@ -2032,6 +2096,7 @@
       "extensions": {
         "link": "https://archerdao.io/",
         "description": null,
+        "categories": ["defi", "protocol", "governance"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x1f3f9d3068568f8040775be2e8c03c103c61f3af"
@@ -2047,6 +2112,7 @@
       "extensions": {
         "link": "https://www.bancor.network/",
         "description": "Bancor is a blockchain protocol that allows users to convert between different tokens directly as opposed to exchanging them on cryptocurrency markets. The project offers a network, which we’ll discuss soon, that works to bring liquidity to the majority of tokens that lack a consistent supply/demand in exchanges. That network is built on smart contracts and a new class of cryptocurrencies that the team calls “Smart Tokens.” Bancor is looking to provide support to the illiquidity that currently exists within the cryptocurrency market. Illiquidity isn’t so much an issue for top coins like <a href=\"https://www.coingecko.com/en/coins/bitcoin\">Bitcoin</a> or <a href=\"https://www.coingecko.com/en/coins/ethereum\">Ethereum</a> because there are always buyers and sellers looking to exchange those coins. It is definitely an issue, however, for the thousands of other tokens that may serve legitimate decentralized purposes but haven’t attracted enough attention in the market to be liquid.\r\n\r\nBa...",
+        "categories": ["defi", "exchange", "protocol", "exchange"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c"
@@ -2062,6 +2128,7 @@
       "extensions": {
         "link": "https://ruletka.fun",
         "description": "Ruletka (RTK) is an incentive-based deflationary game currency. its 1 in 6 chance burn mechanism simulates the Russian Roulette and is used in games by reward-seeking players. Buying and selling on Uniswap is risk-free of getting shot!",
+        "categories": ["gaming", "casino"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x1f6deadcb526c4710cf941872b86dcdfbbbd9211"
@@ -2077,6 +2144,7 @@
       "extensions": {
         "link": "https://for.tube/home",
         "description": "ForTube is the leading global DeFi lending platform launched by The Force Protocol. It is committed to providing decentralized lending services for cryptoasset enthusiasts around the world, supporting most of the world's popular assets. ForTube is based on smart contracts and automated algorithm technology. Users can deposit tokens to earn interest, pledge to borrow tokens and pay interests.  ForTube's interest rate is determined by market supply and demand. Assets are controlled by users. ForTube allows users to deposit and withdraw anytime, borrow and repay anytime globally.",
+        "categories": ["defi", "lending", "protocol"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x1fcdce58959f536621d76f5b7ffb955baa5a672f"
@@ -2092,6 +2160,7 @@
       "extensions": {
         "link": "https://nsure.network/",
         "description": "NSURE is the governance token for the Nsure Network. Nsure Network is a decentralised insurance project that borrows the idea of Lloyd’s of London, a market place to trade insurance risks, where premiums are determined by a Dynamic Pricing Model. In this model, capital supply and demand from the entire platform determines the price jointly, similar to the pricing mechanism in the free market, by having Nsure tokens backing the policies bought. The price is self-adjustable to the movement of supply and demand, subject to the model moderately stabilizing the price change.",
+        "categories": ["defi", "access", "protocol", "governance"],
         "ogImage": "https://nsure.network/nsure-network.png",
         "originChainId": 1,
         "originAddress": "0x20945ca1df56d237fd40036d47e866c7dccd2114"
@@ -2107,6 +2176,7 @@
       "extensions": {
         "link": "https://sale.conceal.cloud/home",
         "description": "Wrapped Conceal ($wCCX) Provides an untraceable gateway to and from the Ethereum ecosystem from the Conceal Network ecosystem. Wrapped Conceal ($wCCX) is simply an ERC20 token that represents the real Conceal coin $CCX on the Ethereum ecosystem. Having an ERC20 token representation allows Conceal Network to integrate into the Ethereum ecosystem, which includes wallets, dapps, and smart contracts.",
+        "categories": ["wrapped", "privacy"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x21686f8ce003a95c99acd297e302faacf742f7d4"
@@ -2122,6 +2192,7 @@
       "extensions": {
         "link": "https://www.ovr.ai/",
         "description": "OVR is the decentralized infrastructure for the spatial web, merging physical and virtual world through Augmented Reality, creating a new dimension where everything is possible.",
+        "categories": ["infrastructure", "gaming"],
         "ogImage": "https://www.ovr.ai/wp-content/uploads/static/social_img.jpg",
         "originChainId": 1,
         "originAddress": "0x21bfbda47a0b4b5b1248c767ee49f7caa9b23697"
@@ -2137,6 +2208,7 @@
       "extensions": {
         "link": "http://www.augur.net/",
         "description": "Augur is a trustless, decentralized platform for prediction markets. Augur is an <a href=\"https://www.coingecko.com/en/coins/ethereum\">Ethereum</a>-based decentralized prediction market that leverages the wisdom of the crowds to create a search engine for the future that runs on its own token, REP. Augur allows users to create their markets for specific questions they may have and to profit from the trading buys while allowing users to buy positive or negative shares regarding the outcome of a future event.\r\n\r\nPrediction markets are markets created to trade the probability of an event happening. The market prices indicate what the crowd thinks the probability of an event happening. Predictive markets have shown to have been effective in accurately forecasting many results however it is still not widely used due to the many regulatory hurdles involved in setting up such a market. Augur aims to set up such a market in a decentralized manner.\r\n\r\nAugur is an Ethereum-based decentralized...",
+        "categories": ["protocol", "governance", "defi", "access"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x221657776846890989a759ba2973e427dff5c9bb"
@@ -2152,6 +2224,7 @@
       "extensions": {
         "link": "http://cloverprotocol.biz/",
         "description": "A completely /biz/-run DeFi project. The network is governed by token owners, with a distribution as widely within the /biz/ community as possible via the fair launch. As chainlinkers understand that the financial system is slowly but surely becoming like LEGO bricks, there is opportunity at the edges to innovate as the bull run for Bitcoin, DeFi and daily /biz/ volume itself draw near.",
+        "categories": ["defi", "protocol", "infrastructure", "governance"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x22222c03318440305ac3e8a7820563d6a9fd777f"
@@ -2167,6 +2240,7 @@
       "extensions": {
         "link": "https://unn.finance",
         "description": "UNION is a technology platform that combines bundled protection and a liquid secondary market with a multi-token model. DeFi participants manage their multi-layer risks across smart contracts and protocols in one scalable system. UNION decreases the barriers to entry for retail users and lays the foundation for institutional investors.",
+        "categories": ["defi", "protocol", "governance"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x226f7b842e0f0120b7e194d05432b3fd14773a9d"
@@ -2182,6 +2256,7 @@
       "extensions": {
         "link": "https://cocktail.money/",
         "description": null,
+        "categories": ["defi", "protocol"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x22b6c31c2beb8f2d0d5373146eed41ab9ede3caf"
@@ -2197,6 +2272,7 @@
       "extensions": {
         "link": "https://nuggets.life/",
         "description": "Nuggets is a consumer blockchain platform giving users a single biometric tool for login, payment and identity verification, without sharing or storing private data.\r\n\r\n",
+        "categories": ["infrastructure", "access", "transactional", "privacy"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x245ef47d4d0505ecf3ac463f4d81f41ade8f1fd1"

--- a/index/polygon/erc20.json
+++ b/index/polygon/erc20.json
@@ -16,6 +16,7 @@
       "extensions": {
         "link": "https://timeraiders.io/",
         "description": "Xpendium ($XPND) is the native token for Time Raiders. Time Raiders is a fast-paced Shoot and Loot, Time Travel, Play-To-Earn, NFT game. Players travel through time and fight enemies to find loot. They can use this precious loot to power up their characters and weapons, craft it into new items, or sell it. Everything in the game is an NFT that can be traded for Xpendium ($XPND).",
+        "categories": ["gaming", "shooter", "action", "p2e"],
         "ogImage": null,
         "originChainId": 137,
         "originAddress": ""
@@ -31,6 +32,7 @@
       "extensions": {
         "link": "https://quickswap.exchange/",
         "description": "Quickswap is a decentralized exchange (DEX) on the Polygon Network. It is a based on the Uniswap V2 AMM protocol and allows users on Polygon to trade tokens through a liquidity pool.",
+        "categories": ["exchange", "protocol", "lending", "defi"],
         "ogImage": null,
         "originChainId": 137,
         "originAddress": ""
@@ -46,6 +48,7 @@
       "extensions": {
         "link": "https://quickswap.exchange/",
         "description": "Quickswap is a decentralized exchange (DEX) on the Polygon Network. It is a based on the Uniswap V2 AMM protocol and allows users on Polygon to trade tokens through a liquidity pool.",
+        "categories": ["exchange", "protocol", "lending", "defi"],
         "ogImage": null,
         "originChainId": 137,
         "originAddress": ""
@@ -61,6 +64,7 @@
       "extensions": {
         "link": "https://www.binance.com/",
         "description": "As the native coin of Binance Chain, BNB has multiple use cases: fueling transactions on the Chain, paying for transaction fees on Binance Exchange, making in-store payments, and many more.",
+        "categories": ["chain", "governance", "gas", "smart-contract", "infrastructure", "reward", "staking", "value", "access", "bridged", "bnb"],
         "ogImage": null,
         "originChainId": 56,
         "originAddress": "0x0000000000000000000000000000000000000000"
@@ -76,6 +80,7 @@
       "extensions": {
         "link": "https://www.circle.com/en/usdc",
         "description": "TEST CURRENCY, NOT THE REAL USDC. USDC is a token tracking the price of 1 USD.",
+        "categories": ["usd-stablecoin", "transactional", "usdc"],
         "ogImage": "https://www.circle.com/hubfs/share-USDC.png#keepProtocol",
         "originChainId": 1,
         "originAddress": "",
@@ -92,6 +97,7 @@
       "extensions": {
         "link": "https://www.circle.com/en/usdc",
         "description": "TEST CURRENCY, NOT THE REAL USDC. USDC is a token tracking the price of 1 USD.",
+        "categories": ["usd-stablecoin", "transactional", "usdc"],
         "ogImage": "https://www.circle.com/hubfs/share-USDC.png#keepProtocol",
         "originChainId": 1,
         "originAddress": ""
@@ -107,6 +113,7 @@
       "extensions": {
         "link": "https://www.circle.com/en/usdc",
         "description": "TEST CURRENCY, NOT THE REAL USDC. USDC is a token tracking the price of 1 USD.",
+        "categories": ["usd-stablecoin", "transactional", "usdc"],
         "ogImage": "https://www.circle.com/hubfs/share-USDC.png#keepProtocol",
         "originChainId": 1,
         "originAddress": ""
@@ -122,6 +129,7 @@
       "extensions": {
         "link": "https://makerdao.com/",
         "description": "Dai is the native stablecoin for the Maker protocol. It is the world’s first crypto-collateralized and decentralized stablecoin, whose value is soft pegged to the US Dollar. The collateralized assets backing Dai are other cryptocurrencies instead of fiat and are held within smart contracts rather than in institutions.",
+        "categories": ["usd-stablecoin", "stablecoin", "transactional", "defi", "protocol", "maker"],
         "ogImage": "https://makerdao.com/dai.png",
         "originChainId": 1,
         "originAddress": "0x6b175474e89094c44da98b954eedeac495271d0f"
@@ -137,6 +145,7 @@
       "extensions": {
         "link": "https://matic.network",
         "description": "Matic Network provides scalable, secure and instant Ethereum transactions. It is built on an implementation of the PLASMA framework and functions as an off chain scaling solution. Matic Network offers scalability solutions along with other tools to the developer ecosystem, which enable Matic to seamlessly integrate with dApps while helping developers create an enhanced user experience.",
+        "categories": ["chain", "protocol", "governance", "gas", "smart-contract", "infrastructure", "reward", "staking", "layer2"],
         "ogImage": "/banners/matic-network-1x1.png",
         "originChainId": 1,
         "originAddress": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
@@ -153,6 +162,7 @@
       "extensions": {
         "link": "https://mechachain.io/",
         "description": "Build your own Mecha, fight for the future of humanity in the outer space and earn precious Mechaniums. MechaChain is a mobile play-to-earn Mecha fighting game where the player can customize their own robot by assembling NFTs and earn cryptocurrency through fun and competitive team fights.",
+        "categories": ["gaming", "action", "p2e", "pvp", "sci-fi"],
         "ogImage": "https://mechachain.io/wp-content/uploads/Logo-Token-White-copie2.png.webp",
         "originChainId": 1,
         "originAddress": "0xc5bcc8ba3f33ab0d64f3473e861bdc0685b19ef5"
@@ -168,6 +178,7 @@
       "extensions": {
         "link": "https://unilend.finance/",
         "description": "UniLend is a permission-less DeFi protocol that combines spot trading services and lending/borrowing functionality within the same platform. Whereas current DeFi protocols support only ~30 assets, anyone can list any ERC20 asset on UniLend for decentralized trading and lending/borrowing. UFT token is UniLend's native governance token; holders of UFT can create proposals for, and vote on, a number of factors relating to the functioning of the protocol.",
+        "categories": ["exchange", "defi", "lending", "protocol", "governance"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1"
@@ -183,6 +194,7 @@
       "extensions": {
         "link": "https://yearn.finance",
         "description": "Yearn Finance is a suite of products in Decentralized Finance (DeFi) that provides lending aggregation, yield generation, and insurance on the Ethereum blockchain. The protocol is maintained by various independent developers and is governed by YFI holders.\r\n\r\nIt started out as a passion project by Andre Cronje to automate the process of switching capital between lending platforms in search of the best yield offered, as the lending yield is a floating rate rather than fixed rate. Funds are shifted between dYdX, AAVE, and Compound automatically as interest rates change between these protocols. \r\n\r\nThe service offered includes major USD tokens such as DAI, USDT, USDC, and TUSD. For example, if a user deposits DAI into yearn.finance, the user will receive yDAI token in return, which is a yield-bearing DAI token. \r\n\r\nLater on, it collaborated with Curve Finance to release a yield-bearing USD tokens pool that includes four y-tokens: yDAI, yUSDT, yUSDC and yTUSD, it is named as yUSD. \r\n\r\nY...",
+        "categories": ["exchange", "defi", "lending", "protocol", "access", "governance"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e"
@@ -198,6 +210,7 @@
       "extensions": {
         "link": "https://decentraland.org/",
         "description": "Decentraland is an Ethereum-powered virtual reality platform. In this virtual world, you purchase plots of land that you can later traverse, build upon, and monetize. There’s no limit to what you can do. It’s the first digital platform that’s completely owned by its users. Similar to games like Skyrim and Fallout, Decentraland is an all-immersive virtual universe. However, instead of playing on a 2-dimensional screen, you participate in a 3-dimensional world. It seems to be the logical next step before creating full-blown AI-based games in the physical space à la Westworld. Similar groupings on LAND comprise Districts. Districts are basically communities that revolve around a shared theme. For example, there may be a District just for crypto enthusiasts with cryptocurrency apps and services.\r\n\r\nThe Decentraland team is led by Ari Meilich (Project Lead) and Esteban Ordano (Tech Lead). Ordano previously worked at <a href=\"https://bitpay.com/\">Bitpay</a> as a software engineer and foun...",
+        "categories": ["gaming", "infrastructure", "reward", "open-world", "simulation", "casual"],
         "ogImage": "/static/scenes4-2ef0a5fdf1ed8717a126299d0a46f3b5.jpg",
         "originChainId": 1,
         "originAddress": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942"
@@ -213,6 +226,7 @@
       "extensions": {
         "link": "https://www.parachutetoken.com/",
         "description": "Parachute was started as a community of people who loved cryptocurrency. Today, we're building the way friends and businesses use crypto in their daily lives. ",
+        "categories": ["governance", "access"],
         "ogImage": "https://static.wixstatic.com/media/5920d4_8a52ca5bdd8b4d6ea913995d42b28f1a~mv2.png/v1/fill/w_621,h_441,al_c/5920d4_8a52ca5bdd8b4d6ea913995d42b28f1a~mv2.png",
         "originChainId": 1,
         "originAddress": "0x1beef31946fbbb40b877a72e4ae04a8d1a5cee06"
@@ -228,6 +242,7 @@
       "extensions": {
         "link": "https://keep3r.network/",
         "description": null,
+        "categories": ["infrastructure", "access", "rwa", "reward"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44"
@@ -243,6 +258,7 @@
       "extensions": {
         "link": "https://uniswap.org/",
         "description": null,
+        "categories": ["exchange", "governance", "defi", "uniswap"],
         "ogImage": "https://uniswap.org/twitter-card.jpg",
         "originChainId": 1,
         "originAddress": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984"
@@ -258,6 +274,7 @@
       "extensions": {
         "link": "https://www.sapien.network/",
         "description": "About Sapien\r\nWhat is Sapien?\r\nSapien is an Ethereum-based social network built for humans. Launched as an undergraduate project by Ankit Bhatia & Rob Giometti at UC Berkeley in 2017, Sapien is building a decentralized, private social network built on a foundation of independent, self-governing communities called Tribes which all participate in the SPN token economy.\r\n\r\nThe company is established on a principle of “Humans First,” which means Sapien will stand by these pledges:\r\n\r\nData sovereignty: as a social network, Sapien knows that privacy is paramount and will never collect personal data without consent\r\nSelf-governance: Sapien commits to give communities the tools they need to guide and protect their communities, so it will always be people who moderate and promote content, never an exploitable algorithm\r\nHumanity: Sapien is built by humans for humans, not trolls or bots, and the platform aims to make it incredibly hard for malicious users or content to spread across the netwo...",
+        "categories": ["access", "reward", "governance", "infrastructure"],
         "ogImage": "http://s3.amazonaws.com/sapien-default-tribes/sapien_logo.png",
         "originChainId": 1,
         "originAddress": "0x20f7a3ddf244dc9299975b4da1c39f8d5d75f05a"
@@ -273,6 +290,7 @@
       "extensions": {
         "link": "https://www.wbtc.network/",
         "description": null,
+        "categories": ["value", "reward", "infrastructure", "wrapped", "bridged"],
         "ogImage": "https://wbtc.network/assets/WBTC-icon.svg",
         "originChainId": 1,
         "originAddress": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599"
@@ -288,6 +306,7 @@
       "extensions": {
         "link": "https://drakoin.drakons.io",
         "description": "Drakoin, an ERC-20 token designed and developed with the main purpose as an in-app virtual currency inside Drakons, a Decentralized Application (DApp). Drakoin is a deflationary token with a variable burn and staking rate.",
+        "categories": ["gaming", "staking", "reward", "transactional", "value"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x2369686fc9fb6e1fdc46541891568c2f341906ef"
@@ -303,6 +322,7 @@
       "extensions": {
         "link": "https://hex.com",
         "description": "Launched on December 2, 2019 by Richard Heart and team, HEX is the first certificate of deposit on the blockchain, essentially time deposits that gain interest, HEX is an ERC20 Token that runs over the Ethereum network\r\n",
+        "categories": ["defi", "lending", "staking", "reward"],
         "ogImage": "https://hex.com/img/TwitterCard_Main_V3.jpg",
         "originChainId": 1,
         "originAddress": "0x2b591e99afe9f32eaa6214f7b7629768c40eeb39"
@@ -318,6 +338,7 @@
       "extensions": {
         "link": "https://kiwi-token.com/",
         "description": "KIWI is a mineable ERC20/EIP-918 token, and it has no pre-mine. The project was first announced in Bitcointalk in May 6, 2018. Today KIWI is used in payments, NFT trading, engagement, and community development. It can be solo-mined using CPU or GPU.",
+        "categories": ["transactional", "exchange", "art", "reward", "infrastructure"],
         "ogImage": "https://img1.wsimg.com/isteam/ip/caef461b-2437-434e-ab3d-1657fa2c42a8/Laura_Mine__Red_Star__West_Virginia._September.jpg",
         "originChainId": 1,
         "originAddress": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d"
@@ -333,6 +354,7 @@
       "extensions": {
         "link": "https://www.dark.build/",
         "description": null,
+        "categories": ["defi", "exchange", "governance", "staking", "reward"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x3108ccfd96816f9e663baa0e8c5951d229e8c6da"
@@ -348,6 +370,7 @@
       "extensions": {
         "link": "https://powerpool.finance",
         "description": null,
+        "categories": ["defi", "ai", "infrastructure", "governance", "staking", "reward"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1"
@@ -363,6 +386,7 @@
       "extensions": {
         "link": "https://deflectprotocol.io",
         "description": "DeFi Hybrid of Frictionless earning, Staking Pools, Locked Liquidity, Supply Burn and Boosts",
+        "categories": ["defi", "staking", "reward", "lending"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x3aa5f749d4a6bcf67dac1091ceb69d1f5d86fa53"
@@ -378,6 +402,7 @@
       "extensions": {
         "link": "https://www.aavegotchi.com/",
         "description": "GHST is the eco-governance token of Aavegotchi. Use GHST to purchase various digital assets within the Aavegotchi universe, such as Aavegotchi portals & wearables. Hold GHST so your Aavegotchi can participate in DAO governance, and earn GHST by excelling at Aavegotchi rarity farming.",
+        "categories": ["gaming", "mmo", "action", "simulation"],
         "ogImage": "https://aavegotchi.com/aavegotchi.png",
         "originChainId": 1,
         "originAddress": "0x3f382dbd960e3a9bbceae22651e88158d2791550"
@@ -393,6 +418,7 @@
       "extensions": {
         "link": "https://www.minereum.com/",
         "description": "There was no ICO for Minereum. Instead Minereum tokens were given away to Genesis Addresses Collection during 14-15 April 2017. Announcement were made openly in cryptocurrency forums and a total of 4268 Genesis Addresses were collected. Each Genesis Addresses were given 32,000 coins resulting in a total supply of 136,576,000 MNE. ",
+        "categories": ["infrastructure", "access", "staking", "reward"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x426ca1ea2406c07d75db9585f22781c096e3d0e0"
@@ -408,6 +434,7 @@
       "extensions": {
         "link": "https://mcdex.io/",
         "description": null,
+        "categories": ["exchange", "access", "defi", "governance"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42"
@@ -423,6 +450,7 @@
       "extensions": {
         "link": "http://cherryhotwife.com/tour/",
         "description": null,
+        "categories": ["access", "ai", "transactional"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x4ecb692b0fedecd7b486b4c99044392784877e8c"
@@ -438,6 +466,7 @@
       "extensions": {
         "link": "https://www.paxos.com/busd/",
         "description": "Binance USD (BUSD) is a stable coin pegged to USD that has received approval from the New York State Department of Financial Services (NYDFS). BUSD will be available for direct purchase and redemption at a rate of 1 BUSD = 1 USD. ",
+        "categories": ["usd-stablecoin", "transactional", "bnb"],
         "ogImage": "https://www.paxos.com/wp-content/uploads/2019/09/busd_logo_black_flushleft-300x138.png",
         "originChainId": 1,
         "originAddress": "0x4fabb145d64652a948d72533023f6e7a623c7c53"
@@ -453,6 +482,7 @@
       "extensions": {
         "link": "https://chain.link/",
         "description": "Chainlink is a decentralized oracle service, the first of its kind. When <a href=\"https://www.coingecko.com/en/coins/ethereum\">Ethereum</a> went live in 2015, it revolutionized what blockchain could bring to enterprise solution and traditional business. Blockchain was no longer just a medium for new age financial transaction, confined to <a href=\"https://www.coingecko.com/en/coins/bitcoin\">Bitcoin’s</a> potential to disrupt traditional currency exchange. With Ethereum powered smart contracts, Vitalik Buterin opened up a Pandora’s Box of use cases for blockchain technology. Problem is, per their design, smart contracts can only manage data on the blockchain. Their potential, the ability to provide tamperproof, decentralized applications for uses the world over, is still largely untapped, as many of the smart contract programs built on Ethereum lack a bridge to the real world industries they’re trying to improve.\r\n\r\nChainlink’s first component consists of on-chain contracts deployed o...",
+        "categories": ["governance", "transactional", "value", "infrastructure", "staking", "bridged"],
         "ogImage": "https://assets-global.website-files.com/5f6b7190899f41fb70882d08/5fa2e075cfcf344baa0e9063_chainlink-open-graph-images_home%20(with%20illustration).png",
         "originChainId": 1,
         "originAddress": "0x514910771af9ca656af840dff83e8264ecf986ca"
@@ -468,6 +498,7 @@
       "extensions": {
         "link": "https://gamecredits.org/",
         "description": "GameCredits is a digital currency that is created to support games and their developers. The crowdfunding platform Game4commit makes it possible for developers to raise money for their game projects. In the future, it might also be possible to offer GameCredits as a reward for gamers in the game. This creates a whole new economy for mobile and online gaming. GameCredits is a rebrand of Gamerscoin. \r\n",
+        "categories": ["gaming", "access", "reward", "defi"],
         "ogImage": "https://gamecredits.org/wp-content/uploads/2020/05/GAME-Credits-logoS.png",
         "originChainId": 1,
         "originAddress": "0x63f88a2298a5c4aee3c216aa6d926b184a4b2437"
@@ -483,6 +514,7 @@
       "extensions": {
         "link": "https://makerdao.com/",
         "description": "Dai is the native stablecoin for the Maker protocol. It is the world’s first crypto-collateralized and decentralized stablecoin, whose value is soft pegged to the US Dollar. The collateralized assets backing Dai are other cryptocurrencies instead of fiat and are held within smart contracts rather than in institutions.",
+        "categories": ["usd-stablecoin", "stablecoin", "transactional", "defi", "protocol", "maker"],
         "ogImage": "https://makerdao.com/dai.png",
         "originChainId": 1,
         "originAddress": "0x6b175474e89094c44da98b954eedeac495271d0f"

--- a/index/polygon/erc20.json
+++ b/index/polygon/erc20.json
@@ -3312,6 +3312,7 @@
       "extensions": {
         "link": "http://truefi.io/",
         "description": null,
+        "categories": ["defi", "lending", "protocol", "reward", "governance"],
         "ogImage": "https://d3n32ilufxuvd1.cloudfront.net/5e8f7529722272005d1c6e41/2350777/screenshot-d4ffa2c8-a99c-402a-8721-86bbb8d4afe2_readyscr_1024.jpg",
         "originChainId": 1,
         "originAddress": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784"
@@ -3327,6 +3328,7 @@
       "extensions": {
         "link": "https://mysterium.network/",
         "description": null,
+        "categories": ["privacy", "infrastructure", "access", "defi"],
         "ogImage": "https://mysterium.network/wp-content/uploads/2019/10/Asset-4Team.png",
         "originChainId": 1,
         "originAddress": "0x4cf89ca06ad997bc732dc876ed2a7f26a9e7f361"
@@ -3342,6 +3344,7 @@
       "extensions": {
         "link": "https://pepemon.world",
         "description": "Pepemons it's just for the very best. Pepemon gotta farm 'em all",
+        "categories": ["gaming", "meme", "defi", "tcg"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x4d2ee5dae46c86da2ff521f7657dad98834f97b8"
@@ -3357,6 +3360,7 @@
       "extensions": {
         "link": "https://menlo.one",
         "description": "Menlo One is a crypto-tech company that has built an open-source framework for making decentralized applications easier and faster to use in the Web 3.0 era. Menlo One decentralized database and Proof-of-Reputation incentive system is the infrastructure that enables the Web 3.0 generation of marketplaces, social media platforms, and future apps to be as fast and performant as their centralized predecessors.\r\n\r\nBuilt on the Ethereum network, Menlo One’s technology offers communication, social, and automation capabilities that were previously unavailable. Together, these improvements address the critical limitations around user experience, security, and compliance that presently stymie widespread adoption. \r\n\r\nMenlo One framework is being used to develop the only token sale marketplace with security, messaging & governance for making the Token Economy mainstream. \r\n",
+        "categories": ["infrastructure", "protocol", "access"],
         "ogImage": "https://www.menlo.one/pdf/facebook-linkedin-og.jpg",
         "originChainId": 1,
         "originAddress": "0x4d807509aece24c0fa5a102b6a3b059ec6e14392"
@@ -3372,6 +3376,7 @@
       "extensions": {
         "link": "http://fantom.foundation",
         "description": "FANTOM is a new DAG based Smart Contract platform that intends to solve the scalability issues of existing public distributed ledger technologies. \r\n\r\nThe platform intends to distinguish itself from the traditional block ledger-based storage infrastructure by attempting to employ an improved version of existing DAG-based pro-tocols. The FANTOM platform adopts a new protocol known as the “Lachesis Protocol” to maintain consensus. This protocol is intended to be integrated into the Fantom OPERA Chain. The aim is to allow applications built on top of the FANTOM OPERA Chain to enjoy instant transactions and near zero transaction costs for all users. \r\n\r\nThe mission of FANTOM is to provide compatibility between all transaction bodies around the world, and create an ecosystem which allows real-time transactions and data sharing with low cost.",
+        "categories": ["chain", "smart-contract", "defi", "infrastructure", "staking", "reward"],
         "ogImage": "https://fantomfoundation-prod-wp-website.s3.ap-southeast-2.amazonaws.com/wp-content/uploads/2021/01/19225127/Fantom-1.png",
         "originChainId": 1,
         "originAddress": "0x4e15361fd6b4bb609fa63c81a2be19d873717870"
@@ -3387,6 +3392,7 @@
       "extensions": {
         "link": "http://fantom.foundation",
         "description": "FANTOM is a new DAG based Smart Contract platform that intends to solve the scalability issues of existing public distributed ledger technologies. \r\n\r\nThe platform intends to distinguish itself from the traditional block ledger-based storage infrastructure by attempting to employ an improved version of existing DAG-based pro-tocols. The FANTOM platform adopts a new protocol known as the “Lachesis Protocol” to maintain consensus. This protocol is intended to be integrated into the Fantom OPERA Chain. The aim is to allow applications built on top of the FANTOM OPERA Chain to enjoy instant transactions and near zero transaction costs for all users. \r\n\r\nThe mission of FANTOM is to provide compatibility between all transaction bodies around the world, and create an ecosystem which allows real-time transactions and data sharing with low cost.",
+        "categories": ["chain", "smart-contract", "defi", "infrastructure", "staking", "reward"],
         "ogImage": "https://fantomfoundation-prod-wp-website.s3.ap-southeast-2.amazonaws.com/wp-content/uploads/2021/01/19225127/Fantom-1.png",
         "originChainId": 1,
         "originAddress": "0x4E15361FD6b4BB609Fa63C81A2be19d873717870"
@@ -3402,6 +3408,7 @@
       "extensions": {
         "link": "http://digix.io/",
         "description": "DIGIX DAO TOKENS. Our vision for the future is a world operating on Smart Contracts. Indeed, we think this vision will become a reality very soon.\r\nIn this world, a stable store of value is needed - that's why we created DGX.\r\nIn order to ensure the success of DGX, we also conceived DGD; a stake in a 'Distributed Autonomous Organisation' that rewards DGD holders based on DGX's success. By participating in the DAO and working on its behalf in curating proposals, you get rewarded based on the usage of DGX in the Ethereum ecosystem.\r\nDGD holders use their tokens to decide on proposals, and determine the best way forward for Digix.",
+        "categories": ["rwa", "value", "transactional", "governance"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x4f3afec4e5a3f2a6a1a411def7d7dfe50ee057bf"
@@ -3417,6 +3424,7 @@
       "extensions": {
         "link": "https://www.celer.network/#",
         "description": "Celer Network is a coherent technology and economic architecture to enable Internet-scale public blockchains through off-chain scaling techniques. It can scale out to billions of transactions per second, and will fully unleash the power of blockchain and decentralized applications.\r\n\r\n\r\nProvably Scalable\r\n\r\nSecure & Private\r\n\r\ndApp-Aware\r\n\r\nRapidly Evolvable\r\n\r\nEasy-to-use\r\n\r\nIncentive Compatible",
+        "categories": ["infrastructure", "layer2", "defi", "protocol"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667"
@@ -3432,6 +3440,7 @@
       "extensions": {
         "link": "https://ftx.com",
         "description": "FTT is FTX's exchange token. Holders get a fraction of exchange fees, a fraction of the liquidation insurance fund, and can use the token as collateral and to get togther OTC spreads on FTX.",
+        "categories": ["exchange", "defi", "access", "infrastructure"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x50d1c9771902476076ecfc8b2a83ad6b9355a4c9"
@@ -3447,6 +3456,7 @@
       "extensions": {
         "link": "https://governordao.org/",
         "description": "Governor is a DAO that seeks to offer Governance-as-a-Service to new DAOs in order to ensure active and fair governance on day zero. GDAO is the governance token that grants voting rights and represents ownership of the project treasury",
+        "categories": ["governance", "defi", "protocol", "access"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x515d7e9d75e2b76db60f8a051cd890eba23286bc"
@@ -3462,6 +3472,7 @@
       "extensions": {
         "link": "https://rakunworld.com/",
         "description": "\"The RAKUN project aims to create a seamless and borderless entertainment ecosystem.\r\n\r\nStarting with (blockchain) games and then by involving other 3rd parties, a singular token will be issued and circulated within RAKUN services. This new secure gaming marketplace contains blockchain technology at its core.\"",
+        "categories": ["gaming", "defi", "reward", "access"],
         "ogImage": "https://teaser.rakunworld.com/assets/img/og-image.png",
         "originChainId": 1,
         "originAddress": "0x51bc0deaf7bbe82bc9006b0c3531668a4206d27f"
@@ -3477,6 +3488,7 @@
       "extensions": {
         "link": "https://www.unfederalreserve.com",
         "description": "The eRSDL ecosystem is like a safe-harbor where sophisticated parties are the \"pricing oracles\" and ordinary people can participate alongside with a reduced chance of being gamed by experts.",
+        "categories": ["defi", "lending", "protocol", "reward"],
         "ogImage": "https://unfederalreserve.com/static/img/sharing-image.png",
         "originChainId": 1,
         "originAddress": "0x5218e472cfcfe0b64a064f055b43b4cdc9efd3a6"
@@ -3492,6 +3504,7 @@
       "extensions": {
         "link": "https://ptokens.io/",
         "description": null,
+        "categories": ["wrapped", "defi", "protocol", "transactional"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x5228a22e72ccc52d415ecfd199f99d0665e7733b"
@@ -3507,6 +3520,7 @@
       "extensions": {
         "link": "https://www.blueprotocol.com/",
         "description": "Decentralized 2-Factor Authentication, Blacklisting, Whitelisting, Auto Smart Contract Scanning, & more.",
+        "categories": ["infrastructure", "defi", "access", "privacy"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x539efe69bcdd21a83efd9122571a64cc25e0282b"
@@ -3522,6 +3536,7 @@
       "extensions": {
         "link": "https://xyo.network/",
         "description": "Our project is called the \"XY Oracle Network\" (XYO Network). The XYO Network enables trustless transactions through an ecosystem of crypto-location components that can bridge the gap from the world of today, to the world of tomorrow.\r\n\r\nThe XYO Network makes it possible for smart contracts to access the real world by using the XYO Network's ecosystem of devices to determine if an object is at a specific XY-coordinate. If it is, one can set up applications which execute transactions in the smart contract.\r\n\r\nThis has opened up a new world of possibilities. The applications of such a technology are infinite.\r\n\r\nTake for example an eCommerce Company. With the XYO Network, they could now offer their premium customers payment-upon-delivery services. To be able to offer this service, the eCommerce company would leverage the XYO Network (which uses XYO Tokens) to write a smart contract.\r\n\r\nThe XYO Network could then track the location of the package being sent to the consumer along every s...",
+        "categories": ["infrastructure", "defi", "protocol", "privacy"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x55296f69f40ea6d20e478533c15a6b08b654e758"
@@ -3537,6 +3552,7 @@
       "extensions": {
         "link": "https://www.revvmotorsport.com/",
         "description": "\"REVV is the main utility token and in-game currency of the branded motorsports games produced by Animoca Brands, including F1® Delta Time, and an upcoming title based on the MotoGP™ intellectual property. With a third title being announced in the coming months.  \r\n\r\nREVV is being leveraged as a cross-title utility, and the driving force behind the ecosystem's Play-to-Earn model.\"",
+        "categories": ["gaming", "defi", "reward", "access", "p2e"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x557b933a7c2c45672b610f8954a3deb39a51a8ca"
@@ -3552,6 +3568,7 @@
       "extensions": {
         "link": "https://justliquidity.org ",
         "description": "JustLiuidity is a Liquidity Protocol which gets integrated with the Uniswap Exchange and rewards liquidity providers with ETH as well JUL token holders with their unique finance and liquidity engine.\r\n\r\nJUL has an elastic supply structure which increases when more liquidity is added, and decreases when liquidity is removed from the Protocol. In this structure, you can just buy JUL on Uniswap and it will gradually appreciate the price of JUL to our “target price”. JustLiquidity users and JUL token holders can expect a very steady and predictable ROI (return on investment) with this brilliant ecosystem.",
+        "categories": ["defi", "protocol", "reward", "staking"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x5580ab97f226c324c671746a1787524aef42e415"
@@ -3567,6 +3584,7 @@
       "extensions": {
         "link": "http://www.thecattoken.com/",
         "description": "We are a community meme token who happens to love cats. ",
+        "categories": ["meme", "defi", "reward"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x56015bbe3c01fe05bc30a8a9a9fd9a88917e7db3"
@@ -3582,6 +3600,7 @@
       "extensions": {
         "link": "https://trism.io/",
         "description": "Trism is a collectables creator and distributor of original digital art supported by it’s own native token ‘trism’. Trism tokens can be used to buy and sell NFT’s from the trism collectables series. NFT art assets are available on opensea and rarible. In the future, trism may offer NFT’s with financial components that enable the project to generate sustainable and predictable recurring revenue. Any recurring revenue generated by the project will be re-distributed to holders via staking of Univ2 LP’s in a farm (Currently targeting Unicrypt as host) through the re-purchase and redistribution of trism tokens in market.  ",
+        "categories": ["art", "defi", "reward", "access"],
         "ogImage": "https://trism.io/wp-content/uploads/2021/01/value.png",
         "originChainId": 1,
         "originAddress": "0x56b4f8c39e07d4d5d91692acf9d0f6d4d3493763"
@@ -3597,6 +3616,7 @@
       "extensions": {
         "link": "https://bzx.network/",
         "description": "bZx is a protocol for borrowing, lending, and margin trading. Borrowing can be done through the Torque while the Fulcrum handles lending and margin trading.",
+        "categories": ["defi", "protocol", "lending", "reward"],
         "ogImage": "https://bzx.network/images/ogp.png",
         "originChainId": 1,
         "originAddress": "0x56d811088235f11c8920698a204a5010a788f4b3"
@@ -3612,6 +3632,7 @@
       "extensions": {
         "link": "https://bluzelle.com/",
         "description": "Bluzelle is a decentralized, scalable database service that aims to provide an effective data storage solution for the newly emerging blockchain ecosystem. It provides a solution to the scaling problems that developers of decentralized applications (dApps) face while using centralized infrastructure and traditional cloud-based databases. \r\n\r\nBluzelle uses reliable ”swarm” technology, in which it stores tiny bits of data in groups of nodes or “swarms” which are distributed across the globe. Since this makes it independent of single data centres, Bluzelle’s scaling ability is limitless. Bluzelle adjusts the number of nodes and their location dynamically, reducing request time and improving overall performance. Bluzelle's swarm technology makes it extremely reliable as it redundantly stores pieces of data across the globe, eliminating a single point of failure. Since there are no data centres, Bluzelle’s resources are provided by network “producers”, who earn funds and pass on the savi...",
+        "categories": ["infrastructure", "defi", "protocol"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x5732046a883704404f284ce41ffadd5b007fd668"
@@ -3627,6 +3648,7 @@
       "extensions": {
         "link": "https://synthetix.io",
         "description": "Synth sUSD by Synthetix\r\nTracks the price of USD through price feeds supplied by an oracle.",
+        "categories": ["stablecoin", "defi", "protocol", "transactional", "synthetix"],
         "ogImage": "/public/logo-x.png",
         "originChainId": 1,
         "originAddress": "0x57ab1ec28d129707052df4df418d58a2d46d5f51"
@@ -3642,6 +3664,7 @@
       "extensions": {
         "link": "https://www.marlin.pro/",
         "description": "High-performance network infrastructure for modern decentralized networks\r\n\r\n",
+        "categories": ["infrastructure", "protocol", "defi"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x57b946008913b82e4df85f501cbaed910e58d26c"
@@ -3657,6 +3680,7 @@
       "extensions": {
         "link": "https://www.hegic.co/",
         "description": null,
+        "categories": ["defi", "protocol", "staking", "reward"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x584bc13c7d411c00c01a62e8019472de68768430"
@@ -3672,6 +3696,7 @@
       "extensions": {
         "link": "https://livepeer.org/",
         "description": "The Livepeer project aims to deliver a live video streaming network protocol that is fully decentralized, highly scalable, crypto token incentivized, and results in a solution which can serve as the live media layer in the decentralized development (web3) stack. In addition, Livepeer is meant to provide an economically efficient alternative to centralized broadcasting solutions for any existing broadcaster. In this document we describe the Livepeer Protocol - a delegated stake based protocol for incentivizing participants in a live video broadcast network in a game-theoretically secure way. We present solutions for the scalable verification of decentralized work, as well as the prevention of useless work in an attempt to game the token allocations in an inflationary system.\r\n\r\nThe Livepeer Token (LPT) is the protocol token of the Livepeer network. But it is not the medium of exchange token. Broadcasters use Ethereum's Ether (ETH) to broadcast video on the network. Nodes who contribu...",
+        "categories": ["infrastructure", "protocol", "defi", "reward"],
         "ogImage": "https://livepeer.org/OG.png",
         "originChainId": 1,
         "originAddress": "0x58b6a8a3302369daec383334672404ee733ab239"
@@ -3687,6 +3712,7 @@
       "extensions": {
         "link": "https://powerledger.io/",
         "description": "Power Ledger (POWR) is an Australian blockchain-based cryptocurrency and energy trading platform that allows for decentralized selling and buying of renewable energy. The platform provides consumers with access to a variety of energy markets around the globe and is meant to be scalable to various energy infrastructures and regulations. The market is based on a dual-token ecosystem operating on two blockchain layers, POWR and Sparkz. POWR tokens allow consumers and hosts providing energy to interface with the ecosystem and are protected through Smart Bond technology. POWR tokens can be converted into Sparkz tokens, which can be used for frictionless transactions in the energy exchange market. The initial coin offering for POWR tokens became the largest crowd funding project in Australia and the 14th highest in the world.\r\n\r\nPower Ledger’s team has immense expertise in both blockchain and electricity markets. They’re comprised of six Board of Directors in addition to over ten full tim...",
+        "categories": ["rwa", "defi", "protocol", "access"],
         "ogImage": "https://www.powerledger.io/wp-content/themes/powerledger/images/pl-logo.jpg",
         "originChainId": 1,
         "originAddress": "0x595832f8fc6bf59c85c527fec3740a1b7a361269"
@@ -3702,6 +3728,7 @@
       "extensions": {
         "link": "https://stake.lido.fi/",
         "description": null,
+        "categories": ["defi", "protocol", "staking", "governance", "reward"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x5a98fcbea516cf06857215779fd812ca3bef1b32"
@@ -3717,6 +3744,7 @@
       "extensions": {
         "link": "https://www.InvestVoyager.com",
         "description": "The Voyager Token (VGX) rewards users within the Voyager crypto broker ecosystem. VGX generates 5% interest when held in the Voyager app and will soon offer cash back rewards, and other exclusive features. VGX, formerly Ethos (ETHOS), can also be stored in its native wallet, the Ethos Universal Wallet. The Ethos Universal Wallet gives users the power to self custody 150+ crypto assets securely.",
+        "categories": ["exchange", "defi", "reward", "access"],
         "ogImage": "https://www.investvoyager.com/images/share/fb-share-image.jpg",
         "originChainId": 1,
         "originAddress": "0x5af2be193a6abca9c8817001f45744777db30756"
@@ -3732,6 +3760,7 @@
       "extensions": {
         "link": "https://xiotri.io",
         "description": "bXIOT is the bridge token between XIOT and RI.",
+        "categories": ["defi", "protocol", "reward"],
         "ogImage": "https://c.xiotri.io/w/dc8b23e634072747836a14b3b430c3a9/images/logo.57.png",
         "originChainId": 1,
         "originAddress": "0x5c4ac68aac56ebe098d621cd8ce9f43270aaa355"
@@ -3747,6 +3776,7 @@
       "extensions": {
         "link": "https://mydogdata.com/",
         "description": "DogData\r\nDogData uses the blockchain and a P2p token ecosystem to manage decentralised Dog care practises. Improving Dog welfare and saving Dog Owners Money.\r\nDogData leverages the knowledge and experience of Dogs breeders using advanced technologies and a gamified system to make Dog welfare rewarding.\r\nDogData is the first platform tokenizing exchanged community interaction or knowledge and experience Data. Rewarded with Dog breed specific suggested product and service discount tokens that create an ecosystem through Dog life data analysis (AI).\r\n\r\nBone (BONE)\r\nBone coins are used to as exchange mechanism representing the value of the Dog’s Life Data. \r\nBone coins can be used to buy DogData Blocks which link to the first international Dog registration and search engine on blockchain. DogData Blocks QR code can be scanned using the DogData mobile app to identify a Dog using the on_block explorer.\r\n",
+        "categories": ["access", "reward", "protocol"],
         "ogImage": "https://mydogdata.com/OG.jpg",
         "originChainId": 1,
         "originAddress": "0x5c84bc60a796534bfec3439af0e6db616a966335"
@@ -3762,6 +3792,7 @@
       "extensions": {
         "link": "https://compound.finance/",
         "description": "Compound protocol balance token",
+        "categories": ["stablecoin", "defi", "lending", "protocol"],
         "ogImage": "https://compound.finance/images/meta-tag.png",
         "originChainId": 1,
         "originAddress": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643"
@@ -3777,6 +3808,7 @@
       "extensions": {
         "link": "https://bonded.finance",
         "description": "The Bonded platform was created to incubate and deploy experimental, high-yield, smart-contract driven, financial instruments that push the bounds of open finance. Bonding is an algorithmic model that aims to unlock, aggregate and de-risk ~50 billion in dormant value distributed amongst untapped digital assets.",
+        "categories": ["defi", "protocol", "lending", "reward"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x5dc02ea99285e17656b8350722694c35154db1e8"
@@ -3792,6 +3824,7 @@
       "extensions": {
         "link": "https://www.synthetix.io/",
         "description": "Synth sETH by Synthetix\r\nTracks the price of Ether through price feeds supplied by an oracle.",
+        "categories": ["defi", "protocol", "synthetix", "staking"],
         "ogImage": "/public/logo-x.png",
         "originChainId": 1,
         "originAddress": "0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb"
@@ -3807,6 +3840,7 @@
       "extensions": {
         "link": "https://dextf.com/",
         "description": "DEXTF Protocol is an non-custodial and oracle-less asset management protocol which makes managing and investing your assets easier than ever before through our highly liquid XTF token funds, one for each fund, which are tradable or redeemable for the underlying assets.",
+        "categories": ["defi", "protocol", "reward", "governance"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x5f64ab1544d28732f0a24f4713c2c8ec0da089f0"
@@ -3822,6 +3856,7 @@
       "extensions": {
         "link": "https://defipie.com/",
         "description": "DeFiPie combines some of the best features of money market protocols, while offering its own unique features, enabling users to enjoy the promises of Decentralized Finance.\r\n\r\nLenders and borrowers can lend or borrow crypto assets in a decentralized manner without passing a registration, doing a KYC and trusting a third party.\r\n\r\nInvestors, traders, and speculators can offer their idle capitals as custom pools with a fixed rate for lending.\r\n\r\nLiquidity Provider can provide assets to existing pools and farm the Governance Token PIE with an annual percentage yield of up to 150%.\r\n\r\nUsers can also stake PoS-based assets in existing pools to earn staking rewards according to the underlying protocols.",
+        "categories": ["defi", "protocol", "lending", "reward"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x607c794cda77efb21f8848b7910ecf27451ae842"
@@ -3837,6 +3872,7 @@
       "extensions": {
         "link": "http://iex.ec/",
         "description": "iExec is an open-source, decentralized cloud computing platform, running on <a href=\"https://www.coingecko.com/en/coins/ethereum\">Ethereum</a> blockchain. iExec allows decentralized applications (dApps) an on-demand access to computing resources and technologies on iExec cloud. iExec has built a blockchain network where dApps can take advantage of cost effective and high-performance resources such as servers, databases, SaaS applications, web hosting and computer farms. iExec’s native cryptocurrency — The RLC token is the primary asset used to access services in iExec infrastructure. RLC is short for “Run on Lots of Computers.”\r\n\r\niExec is headquartered at Lyon, France. It was founded by Gilles Fedak and Haiwu He, both are serving as Chief Executive Officer and Head of Asian-Pacific Region of iExec, respectively. Oleg Lodygensky is the Chief Technical Officer. Gilles Fedak received his PhD from the University of Paris Sud in 2003, and has been working as INRIA (Inventeurs du Monde N...",
+        "categories": ["infrastructure", "defi", "protocol", "access", "ai"],
         "ogImage": "/wp-content/uploads/2019/01/reseaux-sociaux-iExec.png",
         "originChainId": 1,
         "originAddress": "0x607f4c5bb672230e8672085532f7e901544a7375"
@@ -3852,6 +3888,7 @@
       "extensions": {
         "link": "https://cvault.finance/",
         "description": "CORE is a non-inflationary cryptocurrency that is designed to execute profit-generating strategies autonomously with a completely decentralized approach. In existing autonomous strategy-executing platforms a team or single developer is solely responsible for determining how locked funds are used to generate ROI. This is hazardous to the health of the fund as it grows, as it creates flawed incentives, and invites mistakes to be made. CORE does away with this dynamic and instead opts for one with decentralized governance.\r\n\r\nCORE tokens holders will be able to provide strategy contracts and vote on what goes live and when, in order to decentralize autonomous strategy execution. 5% of all profits generated from these strategies are used to auto market-buy the CORE token.",
+        "categories": ["defi", "protocol", "staking", "reward"],
         "ogImage": "/OGImage.png",
         "originChainId": 1,
         "originAddress": "0x62359ed7505efc61ff1d56fef82158ccaffa23d7"
@@ -3867,6 +3904,7 @@
       "extensions": {
         "link": "https://www.morpher.com/",
         "description": "Morpher enables everyone to trade stocks, commodities, and currencies with zero fees and infinite liquidity. Investing on Morpher does not require any counterparties, and comes with incredible advantages like shorting, leverage, fractional shares, and 24/7 access to all markets.\r\n\r\nMPH tokens make the Morpher Protocol possible and power every trade. All investments are made using MPH, and all gains/losses are paid out in MPH.\r\n\r\nThe Morpher Protocol replicates global assets using Virtual Futures, and replaces all middlemen including banks, brokers, and index funds. Virtual Futures do not rely on trading the underlying market, paving the way for completely novel synthetic markets.",
+        "categories": ["defi", "protocol", "reward", "access"],
         "ogImage": "https://www.morpher.com/img/og_airdrop_fb.png",
         "originChainId": 1,
         "originAddress": "0x6369c3dadfc00054a42ba8b2c09c48131dd4aa38"
@@ -3882,6 +3920,7 @@
       "extensions": {
         "link": "https://cyberfi.tech/",
         "description": "CyberFi is a non-custodial intelligent automation platform that is reshaping the DeFi user experience. From beginners to experts, users can finally automate separate actions and events which makes using DeFi platforms simple and easy to use for the masses, while providing advanced features for professionals. CFi is used for governance, fees and subscriptions on the CyberFi platform.",
+        "categories": ["defi", "protocol", "staking", "reward"],
         "ogImage": "https://d3n32ilufxuvd1.cloudfront.net/5decfcc22314d067e4d2a6ee/2187948/screenshot-293ebfd1-d0cf-48af-bca4-d1d5eff653e7_readyscr_1024.jpg",
         "originChainId": 1,
         "originAddress": "0x63b4f3e3fa4e438698ce330e365e831f7ccd1ef4"
@@ -3897,6 +3936,7 @@
       "extensions": {
         "link": "https://www.radixdlt.com/",
         "description": null,
+        "categories": ["infrastructure", "chain", "defi", "protocol"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x6468e79a80c0eab0f9a2b574c8d5bc374af59414"
@@ -3912,6 +3952,7 @@
       "extensions": {
         "link": "https://www.btse.com/en/token",
         "description": "The BTSE token powers the BTSE ecosystem and enhances your trading experience.\r\n",
+        "categories": ["exchange", "defi", "reward", "access"],
         "ogImage": "https://www.btse.com/static/img/btse.png",
         "originChainId": 1,
         "originAddress": "0x666d875c600aa06ac1cf15641361dec3b00432ef"
@@ -3927,6 +3968,7 @@
       "extensions": {
         "link": "https://bns.finance/",
         "description": "Users would get yield in the form of BNSD (BNS defi) a token which we have released specific to this.\r\n\r\nWhat are the salient features of BNSD:\r\n- Super high APYs\r\n- Multiple pools in which you can farm\r\n- Extremely Deflationary release overtime\r\n- Halving built in. 4 halvings happening where block rewards reduce.\r\n- Block rewards start with 1000 rewards per ETH block of BNSD and then reduce based on halving in the following fashion\r\n- 1000 - 500 1 day from genesis block\r\n- 500 - 250 7 days\r\n- 250-125 30 days\r\n- 125 - 100 90 days\r\n- Just 4% of rewards are reserved for dev funds. This is lowest in comparison across other defi projects like Sushi\r\n- Best part 50% of the dev funds are used for buying bns on a periodic basis\r\n- Contract is super clean as there is no mint function there except for the block rewards which are happening every block. So there is no risk associated with it. No time lock needed as only BNSChef can mint rewards and those rewards are specific to block\"",
+        "categories": ["defi", "protocol", "reward", "staking"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x668dbf100635f593a3847c0bdaf21f0a09380188"
@@ -3942,6 +3984,7 @@
       "extensions": {
         "link": "https://wisetoken.net",
         "description": "Wise is a decentralized Ether-backed investment tool programmed to earn users' interest when locked up over periods of time (similar to a bond).",
+        "categories": ["defi", "protocol", "staking", "reward"],
         "ogImage": "https://wisetoken.net/wise-banner.png",
         "originChainId": 1,
         "originAddress": "0x66a0f676479cee1d7373f3dc2e2952778bff5bd6"
@@ -3957,6 +4000,7 @@
       "extensions": {
         "link": "https://koinos.io/",
         "description": "KOIN will be the cryptocurrency that powers Koinos; a high performance, scalable, general purpose blockchain capable of rapid evolution. It is currently a PoW mineable ERC-20 that will determine the initial token supply of the Koinos mainnet at launch.",
+        "categories": ["chain", "smart-contract", "infrastructure", "defi"],
         "ogImage": "https://www.koinos.io/og-image-koinos.png",
         "originChainId": 1,
         "originAddress": "0x66d28cb58487a7609877550e1a34691810a6b9fc"
@@ -3972,6 +4016,7 @@
       "extensions": {
         "link": "https://neutrino.at/",
         "description": "Token, Asset-backed Tokens, Stablecoins, Decentralized Finance (DeFi)\r\nUSD Stablecoin, Neutrino",
+        "categories": ["stablecoin", "defi", "protocol", "transactional"],
         "ogImage": "https://static.tildacdn.com/tild6233-3737-4333-a663-336337323638/Baige_1680900.png",
         "originChainId": 1,
         "originAddress": "0x674c6ad92fd080e4004b2312b45f796a192d27a0"
@@ -3987,6 +4032,7 @@
       "extensions": {
         "link": "https://gnosis.io/",
         "description": "Gnosis is a prediction market platform built as a decentralized application (dapp) on the Ethereum network. The platform includes a multisig wallet as well as a Dutch Exchange, but we’re just going to focus on their flagship product, the prediction market, for this guide. More than just building a prediction market, though, Gnosis is creating an entire infrastructure layer that you can use to build your own prediction market app. A prediction market utilizes user predictions to aggregate information about future events. \r\n\r\nUsers in the market trade tokens that represent the outcome of a certain event. Because some outcomes are more likely to occur than others, these tokens end up having different values in the open market.Olympia is Gnosis’s test version of their prediction market app. They host free tournaments in this product, so you get a chance to try it out without having to spend money. Every two days, the team allocates you a certain amount of Olympia (OLY) tokens that you u...",
+        "categories": ["defi", "protocol", "governance", "access", "privacy"],
         "ogImage": "https://gnosis.io/wp-content/uploads/2020/11/banner-gnosis.png",
         "originChainId": 1,
         "originAddress": "0x6810e776880c02933d47db1b9fc05908e5386b96"
@@ -4002,6 +4048,7 @@
       "extensions": {
         "link": "https://www.sirinlabs.com",
         "description": "Sirin Labs Token is a crypto token developed by blockchain development company Sirin Labs, and is a part of the SIRIN Labs ecosystem. Sirin Labs has been developing the first blockchain smartphone, and every product of this company is committed to using their own blockchain! They promote use of digital currencies and decentralization through SRN tokens.\r\n\r\nSirin Labs was found in 2014. Solarin was their first project, which gained popularity as the most secure phone in the world. Though it was a success and was endorsed by famous celebrities like Leonardo DiCaprio, the company declared a layoff of about one-third of the staff by 2015. The reason they announced was developments in other fields. In late 2017, Sirin Labs announced the ICO (Initial Public Offering) of Sirin Lab Token (SRN) in order to give their operations a new direction. Now, they focus on bringing new technology for mass adoption.\r\n\r\nSIRIN Labs has a vision of creating open source and secure devices for mass adoption...",
+        "categories": ["infrastructure", "access", "privacy"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x68d57c9a1c35f63e2c83ee8e49a64e9d70528d25"
@@ -4017,6 +4064,7 @@
       "extensions": {
         "link": "https://bitbns.com/",
         "description": null,
+        "categories": ["exchange", "defi", "transactional", "access"],
         "ogImage": "https://bitbns.com/img/logos/bitbns-512.png",
         "originChainId": 1,
         "originAddress": "0x695106ad73f506f9d0a9650a78019a93149ae07c"
@@ -4032,6 +4080,7 @@
       "extensions": {
         "link": "https://www.poolz.finance/",
         "description": "Poolz is a swapping protocol that enables startups and project owners to auction their tokens for bootstrapping liquidity. As the blockchain-cryptocurrency community moves closer to absolute decentralization, Poolz empowers innovators in their pre-listing phase, bringing them closer to early-stage investors.",
+        "categories": ["defi", "protocol", "access", "reward"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x69a95185ee2a045cdc4bcd1b1df10710395e4e23"
@@ -4047,6 +4096,7 @@
       "extensions": {
         "link": "https://geeq.io",
         "description": "Geeq is a multi-blockchain platform secured by our Proof of Honesty protocol (PoH), safe enough for your most valuable data, cheap enough for IoT, and flexible enough for any use.",
+        "categories": ["infrastructure", "defi", "protocol", "privacy"],
         "ogImage": "https://geeq.io/wp-content/themes/geeqio/images/Geeq-Blue-Squares-Medium.png",
         "originChainId": 1,
         "originAddress": "0x6b9f031d718dded0d681c20cb754f97b3bb81b78"
@@ -4062,6 +4112,7 @@
       "extensions": {
         "link": "https://phala.network/",
         "description": null,
+        "categories": ["privacy", "infrastructure", "defi", "protocol"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x6c5ba91642f10282b576d91922ae6448c9d52f4e"
@@ -4077,6 +4128,7 @@
       "extensions": {
         "link": "https://holo.host/",
         "description": "Holochain enables a distributed web with user autonomy built directly into its architecture and protocols. Data is about remembering our lived and shared experiences. Distributing the storage and processing of that data can change how we coordinate and interact. With digital integration under user control, Holochain liberates our online lives from corporate control over our choices and information.\r\n\r\nHolochain is an energy efficient post-blockchain ledger system and decentralized application platform that uses peer-to-peer networking for processing agent centric agreement and consensus systems between users.\r\n\r\nHolochain enables any device to have its own chain based ledger system. By using a holographic model for data storage and transfer developers can now create decentralized applications that can scale in multiple dimensions across a network ensuring they are truly distributed. This enables every device on a network to function independently, and only requires the synchronizati...",
+        "categories": ["infrastructure", "chain", "access", "defi"],
         "ogImage": "https://holo.host/wp-content/uploads/holoport-people-og.jpg",
         "originChainId": 1,
         "originAddress": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2"
@@ -4092,6 +4144,7 @@
       "extensions": {
         "link": "https://foundrydao.com/",
         "description": "Foundry: A DAO for Economic Freedom",
+        "categories": ["defi", "protocol", "governance", "reward"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x6c972b70c533e2e045f333ee28b9ffb8d717be69"
@@ -4107,6 +4160,7 @@
       "extensions": {
         "link": "https://rendertoken.com/",
         "description": "OctaneRender® is the world’s first and fastest GPU-accelerated, unbiased, physically correct renderer. Octane uses the graphics card in your computer to render photo-realistic images super fast. With Octane’s parallel compute capabilities, you can create stunning works in a fraction of the time.\r\n\r\nOTOY’s Academy Award®-winning technology is used by leading visual effects studios, artists, animators, designers, architects, and engineers, providing unprecedented creative freedom, new levels of realism, and new economics in content creation and distribution powered by the cloud.\r\n\r\nOTOY® was founded in 2008 by Jules Urbach, Alissa Grainger and Malcolm Taylor. Since then, the company has grown to over 60 employees across four offices with headquarters in Los Angeles, CA.",
+        "categories": ["infrastructure", "defi", "access", "art", "ai"],
         "ogImage": "https://rendertoken.com/assets/images/meta-card.jpg",
         "originChainId": 1,
         "originAddress": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24"
@@ -4122,6 +4176,7 @@
       "extensions": {
         "link": "https://quiverx.io/",
         "description": "QuiverX is a utility token for the QuiverX Capital platform which is focused on tokenizing non-crypto related small and medium businesses.",
+        "categories": ["defi", "protocol", "access", "reward"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x6e0dade58d2d89ebbe7afc384e3e4f15b70b14d8"
@@ -4137,6 +4192,7 @@
       "extensions": {
         "link": "https://www.wrapped.com",
         "description": "Wrapped Filecoin is a 1:1 equivalent of Filecoin represented as an ERC-20 on Ethereum.",
+        "categories": ["wrapped", "defi", "infrastructure", "storage"],
         "ogImage": "images/img_og.jpg",
         "originChainId": 1,
         "originAddress": "0x6e1a19f235be7ed8e3369ef73b196c07257494de"
@@ -4152,6 +4208,7 @@
       "extensions": {
         "link": "https://niftygotchi.com",
         "description": "Eggs of the NiftyGotchi ecosystem.",
+        "categories": ["gaming", "defi", "reward", "access", "p2e"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x6e742e29395cf5736c358538f0f1372ab3dfe731"
@@ -4167,6 +4224,7 @@
       "extensions": {
         "link": "https://nordfinance.io/",
         "description": null,
+        "categories": ["defi", "protocol", "reward", "staking"],
         "ogImage": "https://nordfinance.io/wp-content/uploads/2021/01/Main-illustration.png",
         "originChainId": 1,
         "originAddress": "0x6e9730ecffbed43fd876a264c982e254ef05a0de"
@@ -4182,6 +4240,7 @@
       "extensions": {
         "link": "https://handsofsteel.money/",
         "description": "Our Seller Transfer Only Protocol Initiates Tax (STOP IT) actively taxes sellers while rewarding holders.",
+        "categories": ["gaming", "defi", "reward", "pvp", "strategy"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x6f022e991ea21d26f85f6716c088e2864101dfec"
@@ -4197,6 +4256,7 @@
       "extensions": {
         "link": "https://www.hbg.com",
         "description": "Huobi, the third-largest cryptocurrency exchange in the world, recently announced and launched a new currency. The Huobi Token (HT) rewards exchange users for their loyalty with lowered transaction fees while also carrying its own value in tradable pairs against popular currencies. The hope was to bring greater value to Huobi’s millions of users, mostly located in Asian countries. The launch of the Huobi Token follows in the footsteps of other loyalty-building tokens that other exchanges have launched. The first and most successful of these tokens has been <a href=\"https://www.coingecko.com/en/coins/binancecoin\">Binance Coin (BNB)</a>. The creation of BNB secured Binance’s place as the world’s leading exchange. It offered discounted trading fees in exchange for customer loyalty, primarily functioning as a loyalty rewards system.\r\n\r\nHuobi officially announced its intentions to launch a new token on January 22, 2018. Over the course of 15 days, Huobi would distribute 300 million HT (6...",
+        "categories": ["exchange", "defi", "access", "reward"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x6f259637dcd74c767781e37bc6133cd6a68aa161"
@@ -4212,6 +4272,7 @@
       "extensions": {
         "link": "https://bird.money/",
         "description": "Bird.Money is an ERC20 token which acts as a non-custodial digital asset lending and borrowing platform. Bird.Money is based on current decentralized lending platforms, but with various changes to bring an even more innovative environment.",
+        "categories": ["defi", "protocol", "reward", "ai", "access"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x70401dfd142a16dc7031c56e862fc88cb9537ce0"
@@ -4227,6 +4288,7 @@
       "extensions": {
         "link": "https://www.straitsx.com/xsgd",
         "description": "XSGD is a stablecoin pegged to the Singapore Dollar.",
+        "categories": ["stablecoin", "transactional", "defi"],
         "ogImage": "https://s2.coinmarketcap.com/static/img/coins/64x64/8489.png",
         "originChainId": 1,
         "originAddress": "0x70e8de73ce538da2beed35d14187f6959a8eca96"
@@ -4242,6 +4304,7 @@
       "extensions": {
         "link": "https://axion.network/",
         "description": "Axion is an emerging global monetary system designed to increase the purchasing power of the network participants. Axion offers high-interest yielding time-locked deposits on the Ethereum blockchain, while also offering a first of its kind smart contract powered venture capital fund.",
+        "categories": ["defi", "staking", "reward", "access"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x71f85b2e46976bd21302b64329868fd15eb0d127"
@@ -4257,6 +4320,7 @@
       "extensions": {
         "link": "https://paypolitan.io/",
         "description": null,
+        "categories": ["transactional", "infrastructure", "access"],
         "ogImage": "https://static.tildacdn.com/tild3831-3534-4566-a332-343835316235/43_.png",
         "originChainId": 1,
         "originAddress": "0x72630b1e3b42874bf335020ba0249e3e9e47bafc"
@@ -4272,6 +4336,7 @@
       "extensions": {
         "link": "https://plotx.io/",
         "description": null,
+        "categories": ["defi", "protocol", "staking", "reward"],
         "ogImage": "https://plotx.io/wp-content/uploads/2020/09/Updated-laptop-mockup-transparent-1024x621.png",
         "originChainId": 1,
         "originAddress": "0x72f020f8f3e8fd9382705723cd26380f8d0c66bb"
@@ -4287,6 +4352,7 @@
       "extensions": {
         "link": "https://stakedao.org/",
         "description": "The Stake Dao Token (or SDT) is a governance token which allows users to vote and earn fees generated on Stake DAO via products such as staking and automated investment strategies. \r\n\r\nStake DAO is a new multi-service DeFi platform built by the community which leverages the entire DeFi ecosystem to give users access to the most effective investment strategies. \r\n\r\nToken holders can stake their earned SDT to receive a share of the DAO fees.",
+        "categories": ["defi", "protocol", "staking", "governance", "reward"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x73968b9a57c6e53d41345fd57a6e6ae27d6cdb2f"
@@ -4302,6 +4368,7 @@
       "extensions": {
         "link": "https://noderunners.io",
         "description": "Join the resistance and fight for the decentralised tomorrow",
+        "categories": ["defi", "gaming", "access", "reward"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x739763a258640919981f9ba610ae65492455be53"
@@ -4317,6 +4384,7 @@
       "extensions": {
         "link": "https://www.okex.com/okb",
         "description": "<a href=\"https://www.coingecko.com/en/exchanges/okex\">OKEx</a>, the 2nd most popular cryptocurrency exchange by trading volume, launched its platform token ‘OKB‘ today with 10 trading pairs. On its official support page, OKEx describes OKB is a global utility token issued by the OK Blockchain Foundation. The total available supply of OKB will be one billion tokens (1,000,000,000), with a distribution model that allocates 60% of the supply will be given out to OKEx customers for community building and during marketing campaigns. According to OKEx, the company had officially issued OKB on ERC20 protocol earlier this month. \r\n\r\nThe company denied ICO (initial coin offering) and public fundraising. Reportedly the company had stated that it would be soon shifting the token to its official OK chain and subsequently it will be applied not only on OKEx’s platform but also on other related projects. There will be in total 1 billion tokens supplied globally out of which 600 million coins will...",
+        "categories": ["exchange", "defi", "reward", "access"],
         "ogImage": "https://static.coinall.ltd/cdn/assets/imgs/207/95EDC6DD5D3CBDF8.png",
         "originChainId": 1,
         "originAddress": "0x75231f58b43240c9718dd58b4967c5114342a86c"
@@ -4332,6 +4400,7 @@
       "extensions": {
         "link": "https://www.lition.io/",
         "description": "Lition is a company developing private side chains with deletable data features on top of the Ethereum Blockchain. \r\nAlong with the proprietary layer 2 infrastructure co-innovated with SAP, the world's largest business software provider, we have developed three use cases:\r\n- P2P Energy dApp that currently supplies customers with electricity in over 100 cities in Germany\r\n- Syndicated loan dApp, together with VR-Bank\r\n- Infrastructure layer security tokens for private data management, in collaboration with Tokeny",
+        "categories": ["rwa", "defi", "protocol", "access"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x763fa6806e1acf68130d2d0f0df754c93cc546b2"
@@ -4347,6 +4416,7 @@
       "extensions": {
         "link": "https://dexkit.com/",
         "description": "DexKit (KIT) is the next generation DEX. It uses technology based on ZRX protocol, Uniswap and Kyber, among others, to create an advanced trading, swapping, atomic swap, market making and decentralized erc20 and erc721 whitelabel solutions.",
+        "categories": ["exchange", "defi", "protocol", "access"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x7866e48c74cbfb8183cd1a929cd9b95a7a5cb4f4"
@@ -4362,6 +4432,7 @@
       "extensions": {
         "link": "https://badger.finance/",
         "description": "An elastic BTC-pegged token.",
+        "categories": ["defi", "protocol", "reward", "synthetix"],
         "ogImage": "https://badger.finance/wp-content/uploads/2020/10/Copy-of-Untitled-39.png",
         "originChainId": 1,
         "originAddress": "0x798d1be841a82a273720ce31c822c61a67a601c3"
@@ -4377,6 +4448,7 @@
       "extensions": {
         "link": "https://app.sergs.link",
         "description": "SERGS is an erc20 token that is a part of the SSL ecosystem. SERGS will be used to mint NFTs and a 2.5 % fee is collected on SERGS transactions which is rewarded to SSL holders ",
+        "categories": ["defi", "protocol", "reward"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x79ba92dda26fce15e1e9af47d5cfdfd2a093e000"
@@ -4392,6 +4464,7 @@
       "extensions": {
         "link": "https://morpheus.network",
         "description": "The Morpheus.Network is a full-service, global, automated, supply chain platform for the global trading industry utilizing blockchain technology. This is achieved with Smart Contracts driving the supply chain with predetermined, automated work contracts, shipping & customs documents as well as automated international payments to over 1600 banks globally through integration with the SWIFT Payments Hub. The layering of other blockchain or non-blockchain technologies to be included as necessary objectives in a given Smart Contract further automate any complex supply chain (eg. RFID scans, data transfers). \r\n\r\nThe MRPH token is a “value” based utility within the Morpheus.Network, and is used for the transaction fees to power or \"fuel\" the automation platform.\r\n\r\nWe are currently establishing strategic partners during the development of the platform. These include major logistics and customs brokers, import/export corporations involved in global trade, as well as actual end-users of the ...",
+        "categories": ["infrastructure", "defi", "access", "protocol"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x7b0c06043468469967dba22d1af33d77d44056c8"
@@ -4407,6 +4480,7 @@
       "extensions": {
         "link": "https://www.dfohub.com/",
         "description": "Thanks to the DFO Proxy Contract design, dapps can achieve more security and fast developing, like the standards in the Web2, but the real killer innovation is to make dapp upgradable by voting, for a new generation of Decentralized Applications independent from issuer's forks.\r\n\r\nThe governance Token of DFOhub, the On-Chain Github for Decentralised Flexible Organisations",
+        "categories": ["defi", "protocol", "governance", "access"],
         "ogImage": "https://static.wixstatic.com/media/1ed2ed_c6b36da794f841c3927e4494cd0bc3f5~mv2.png/v1/fill/w_500,h_500,al_c/1ed2ed_c6b36da794f841c3927e4494cd0bc3f5~mv2.png",
         "originChainId": 1,
         "originAddress": "0x7b123f53421b1bf8533339bfbdc7c98aa94163db"
@@ -4422,6 +4496,7 @@
       "extensions": {
         "link": "https://vectorspace.ai/",
         "description": "Using a biomimetic approach, the Vectorspace AI platform will leverage advanced approaches in Natural Language Processing (NLP) and Machine Learning (ML) in order to create dynamic smart \"token baskets\" based on trends rising in context-controlled sentiment, search, social media, and news",
+        "categories": ["ai", "infrastructure", "defi", "protocol"],
         "ogImage": "https://vectorspace.ai/img/Hexagonal_Vectors_Illustration_Image.png",
         "originChainId": 1,
         "originAddress": "0x7d29a64504629172a429e64183d6673b9dacbfce"
@@ -4437,6 +4512,7 @@
       "extensions": {
         "link": "https://golem.network/",
         "description": "Golem is a decentralized supercomputer that is accessible by anyone. The system is made up of the combined power of user’s machines from personal PCs to entire datacenters. Golem is able to compute almost any tasks from CGI rendering through machine learning to scientific learning. It utilizes an <a href\"https://www.coingecko.com/en/coins/ethereum\">ethereum</a>-based transaction system to clear payments between providers, requestors and software developers however it is safe because all computations take place in sandbox environments and are fully isolated from the hosts’ systems. \r\n\r\nThe company released Brass in 2016 which includes Blender and LuxRender which are the two tools for CGI rendering. There are three releases that follows which are Clay, Stone and Iron. Golem has recently updated their Brass Beta and the highlight of this upgrade are the streamlined task creation GUI, the support for partial task restart in case of subtask timeouts and the fix that should alleviate the ...",
+        "categories": ["infrastructure", "defi", "protocol", "access"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x7dd9c5cba05e151c895fde1cf355c9a1d5da6429"
@@ -4452,6 +4528,7 @@
       "extensions": {
         "link": "https://unifty.io",
         "description": "NIF is a utility token for the Unifty NFT ecosystem.",
+        "categories": ["art", "defi", "access", "protocol"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x7e291890b01e5181f7ecc98d79ffbe12ad23df9e"
@@ -4467,6 +4544,7 @@
       "extensions": {
         "link": "https://royale.finance/",
         "description": "Royale is an industry-focused decentralised lending protocol. Its purpose is to create Web 3.0 smart-backed funding solutions using DeFi primitives in order to support the innovation of iGaming products and platforms. We call the combination of iGaming returns, uncorrelated to DeFi cryptoassets but powered by base layer DeFi protocols, iGDeFi.",
+        "categories": ["casino", "defi", "protocol", "reward"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x7eaf9c89037e4814dc0d9952ac7f888c784548db"
@@ -4482,6 +4560,7 @@
       "extensions": {
         "link": "https://aave.com/",
         "description": null,
+        "categories": ["defi", "lending", "protocol", "staking", "governance"],
         "ogImage": "https://aave.com/favicon64.png",
         "originChainId": 1,
         "originAddress": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9"
@@ -4497,6 +4576,7 @@
       "extensions": {
         "link": "http://www.originprotocol.com",
         "description": "Origin Protocol provides a platform for building peer-to-peer marketplaces and e-commerce applications. Users can buy or sell goods and services on these marketplaces, and developers can create their own applications powered by the Origin blockchain. The Origin token (“OGN”) is used as an incentive, payment, and governance token in the Origin ecosystem.\r\n",
+        "categories": ["defi", "protocol", "reward", "access"],
         "ogImage": "https://www.originprotocol.com/static/img/fb-og-img.png",
         "originChainId": 1,
         "originAddress": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26"
@@ -4512,6 +4592,7 @@
       "extensions": {
         "link": "https://www.ankr.com/",
         "description": "Ankr strives to build a resource efficient blockchain framework that truly enables Distributed Cloud Computing (DCC) and provides user-friendly infrastucture for business applications. There are indeed existing cloud solutions, but Ankr is the first one to leverage both blockchain and trusted hardware.\r\n\r\nTechnology Overview\r\nAnkr provides a computation-resource-efficient blockchain and an integrated data feed system leveraging both cryptographic primitives and trusted hardware \r\n\r\nProof of Useful Work\r\nThe Proof of Useful Work (PoUW) consensus enables a self-sustainable blockchain framework. Instead of wasting electricity and computing power on hashes like Bitcoin does, PoUW uses these resources towards useful work tasks provided by enterprises and consumers. The protocol runs on SGX-enabled CPUs with remote attestation to ensure security and confidentiality. The novel PoUW approach unlocks the massive potential of idle computing power around the world by providing enough incentive...",
+        "categories": ["infrastructure", "defi", "staking", "protocol"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x8290333cef9e6d528dd5618fb97a76f268f3edd4"
@@ -4527,6 +4608,7 @@
       "extensions": {
         "link": "https://gains.farm",
         "description": "DeFi protocol combining yield farming with a new use case: a decentralized leveraged trading platform with NFTs",
+        "categories": ["defi", "protocol", "reward", "staking", "art"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x831091da075665168e01898c6dac004a867f1e1b"
@@ -4542,6 +4624,7 @@
       "extensions": {
         "link": "https://exmo.money/",
         "description": "EXMO Coin is the utility token of the largest crypto exchange in Eastern Europe. We are launching our token to optimise your user experience and give you access to the countless benefits of the EXMO exchange.",
+        "categories": ["exchange", "defi", "reward", "access"],
         "ogImage": "http://exmo.money/wp-content/uploads/2019/07/fb_ecmocoin-min-1.png\"",
         "originChainId": 1,
         "originAddress": "0x83869de76b9ad8125e22b857f519f001588c0f62"
@@ -4557,6 +4640,7 @@
       "extensions": {
         "link": "https://www.polkastarter.com/token",
         "description": "POLS token holders will be able to vote on product features, token utility, types of auctions and even decide which projects get to be featured by Polkastarter. ",
+        "categories": ["defi", "protocol", "governance", "access"],
         "ogImage": "https://www.polkastarter.com/assets/metaOG-bd9b24b9ab823359c9ce2b52b3b8ae882d43b85ec0ec11925d4aa46e0b9aad6b.jpg",
         "originChainId": 1,
         "originAddress": "0x83e6f1e41cdd28eaceb20cb649155049fac3d5aa"
@@ -4572,6 +4656,7 @@
       "extensions": {
         "link": "https://zeroutility.com",
         "description": "Zero Utility Token is a human collective of artists, developers and active community members that aim to bring real usecase to the DeFi landscape through innovative products. Our first product \"\"NFT Multisend\"\" is currently live and offers users to send any ERC720/721/1155 NFT tokens to several addresses at once all within one transaction. All proceeds from products go to buy and burn ZUT tokens. We value our community above all else and build our products with them first in mind. Being one of the only rug-proof smart contracts to date, this format of community building will launch DeFi to small communities all over the world. Our NFT initiative is the most ambitious in the space having an in-house group of artists creating original pieces that increase in value as users burn minted copies of their NFT for ETH. \r\n\r\nPure community, all transparency and TRUTH! ZUT!\"",
+        "categories": ["meme", "defi", "reward"],
         "ogImage": "https://www.zeroutility.com/wp-content/uploads/2020/11/photo_2020-11-05_23-44-45.jpg",
         "originChainId": 1,
         "originAddress": "0x83f873388cd14b83a9f47fabde3c9850b5c74548"
@@ -4587,6 +4672,7 @@
       "extensions": {
         "link": "http://unibright.io/",
         "description": "Unibright is a team of developers with 20+ years of experience in business integration. Nowadays most companies have a strong interest in Blockchain technology, but struggle to use it. That is why we created Unibright Framework. Unibright makes it easy to integrate Blockchain technology into existing business.",
+        "categories": ["infrastructure", "defi", "protocol", "access"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e"
@@ -4602,6 +4688,7 @@
       "extensions": {
         "link": "https://www.chonker.finance/",
         "description": "$CHONK is a DeFi + NFT experimental protocol inspired by the popular pineapple $MEME coin. Fish with fat chonkers and get rewarded with NFT cards. ",
+        "categories": ["art", "meme", "defi", "reward"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x84679bc467dc6c2c40ab04538813aff3796351f1"
@@ -4617,6 +4704,7 @@
       "extensions": {
         "link": "https://diadata.org/",
         "description": null,
+        "categories": ["defi", "protocol", "infrastructure", "governance"],
         "ogImage": "https://diadata.org/wp-content/uploads/2019/11/DIA-icon-colour.png",
         "originChainId": 1,
         "originAddress": "0x84ca8bc7997272c7cfb4d0cd3d55cd942b3c9419"
@@ -4632,6 +4720,7 @@
       "extensions": {
         "link": "https://keep.network/",
         "description": "A keep is an off-chain container for private data. Keeps help contracts harness the full power of the public blockchain — enabling deep interactivity with private data.\r\n\r\nKeep Network aims to provide an off-chain “containers” — called keeps — that should keep private data safe from the public blockchain, thereby enabling smart contracts to maximize the full potential of blockchain tech without compromising on transparency or privacy. Keeps will be used to encrypt and store private data, and the keeps are to be protected by secure multi-party computation (sMPC) that allows generating, storing, encrypting and transmitting of data among different users.",
+        "categories": ["privacy", "infrastructure", "defi", "protocol"],
         "ogImage": "https://keep.networkundefined",
         "originChainId": 1,
         "originAddress": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec"
@@ -4647,6 +4736,7 @@
       "extensions": {
         "link": "https://indexed.finance/",
         "description": "Indexed Finance is a project focused on the development of passive portfolio management strategies for the Ethereum network.\r\nIndexed Finance is managed by the holders of its governance token NDX, which is used to vote on proposals for protocol updates and high level index management such as the definition of market sectors and the creation of new management strategies.",
+        "categories": ["defi", "protocol", "governance", "reward"],
         "ogImage": "https://i.imgur.com/TfkmJWJ.png",
         "originChainId": 1,
         "originAddress": "0x86772b1409b61c639eaac9ba0acfbb6e238e5f83"
@@ -4662,6 +4752,7 @@
       "extensions": {
         "link": "https://idle.finance/",
         "description": "IDLE is the Governance Token of Idle Protocol. It allows community participants to vote on-chain proposals and drive the protocol’s future developments.",
+        "categories": ["defi", "protocol", "reward", "governance"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x875773784af8135ea0ef43b5a374aad105c5d39e"
@@ -4670,13 +4761,14 @@
     {
       "chainId": 137,
       "address": "0x7b38c0d5dfc91d0a3fef2f8dab3be404c1f61fa4",
-      "name": "Reserve Rights Toke",
+      "name": "Reserve Rights Token",
       "symbol": "RSR",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/8365/large/Reserve_Rights.png?1557737411",
       "extensions": {
         "link": "https://reserve.org/",
         "description": "Reserve aims to build a stable, decentralized, asset-backed cryptocurrency and a digital payment system that scales supply with demand and maintains 100% or more collateral backing. Ultimately, Reserve’s goal is to create a universal store of value – particularly in regions with unreliable banking infrastructure and regions where hyperinflation is an issue. The Reserve system will interact with three kinds of tokens: \r\n\r\n(1) The Reserve token (RSV), which is a stable cryptocurrency that can be held and spent the way we use normal fiat money; \r\n\r\n(2) The Reserve Rights token (RSR), a protocol token used to facilitate the stability of RSV.\r\n\r\n(3) A growing variety of tokenized real-world assets (such as other stablecoins) that are held by the Reserve smart contract to back RSV. ",
+        "categories": ["defi", "stablecoin", "protocol", "governance"],
         "ogImage": "https://assets.website-files.com/5c0651c367dd7b1992d59e02/5c0f6da6300e0bb450771327_reserve-thumbnail.png",
         "originChainId": 1,
         "originAddress": "0x8762db106b2c2a0bccb3a80d1ed41273552616e8"
@@ -4692,6 +4784,7 @@
       "extensions": {
         "link": "https://coinartist.io/",
         "description": null,
+        "categories": ["gaming", "art", "defi", "reward", "access"],
         "ogImage": "/coinseden.jpeg",
         "originChainId": 1,
         "originAddress": "0x87b008e57f640d94ee44fd893f0323af933f9195"
@@ -4707,6 +4800,7 @@
       "extensions": {
         "link": "https://nftx.org/#/",
         "description": "NFT-backed index funds on Ethereum",
+        "categories": ["art", "defi", "protocol", "reward", "access"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x87d73e916d7057945c9bcd8cdd94e42a6f47f776"
@@ -4722,6 +4816,7 @@
       "extensions": {
         "link": "https://88mph.app/",
         "description": "\r\n\r\n\r\n\r\n\r\n\r\n\r\n",
+        "categories": ["defi", "protocol", "staking", "reward"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x8888801af4d980682e47f1a9036e589479e835c5"
@@ -4737,6 +4832,7 @@
       "extensions": {
         "link": "https://www.opium.network/",
         "description": "OPIUM is a governance token that gives users a right to govern Opium Protocol.",
+        "categories": ["defi", "protocol", "reward", "access"],
         "ogImage": "https://opium.network/assets/image.png",
         "originChainId": 1,
         "originAddress": "0x888888888889c00c67689029d7856aac1065ec11"
@@ -4752,6 +4848,7 @@
       "extensions": {
         "link": "https://marble.cards/",
         "description": "Official prize token of Marble.Cards",
+        "categories": ["rwa", "defi", "value"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x8888889213dd4da823ebdd1e235b09590633c150"
@@ -4767,6 +4864,7 @@
       "extensions": {
         "link": "https://uniris.io",
         "description": "Uniris is disrupting the way people make transactions by removing credit cards, passwords and keys: with a tamper-proof identification system based on the encrypted venous network and a evolutive blockchain, you can access securely any network (payments, IoT, digital IDs, etc.) with the tip of a finger.",
+        "categories": ["infrastructure", "privacy", "access", "protocol"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x8a3d77e9d6968b780564936d15b09805827c21fa"
@@ -4782,6 +4880,7 @@
       "extensions": {
         "link": "https://get-protocol.io/",
         "description": "The GET Protocol offers a blockchain-based smart ticketing solution that can be used by everybody who needs to issue admission tickets in an honest and transparent way.",
+        "categories": ["infrastructure", "defi", "access", "protocol"],
         "ogImage": "https://get-protocol.io/images/share.jpg",
         "originChainId": 1,
         "originAddress": "0x8a854288a5976036a725879164ca3e91d30c6a1b"
@@ -4797,6 +4896,7 @@
       "extensions": {
         "link": "https://jarvis.network/",
         "description": "A trading platform and its set of financial protocols to gain exposure to any assets, through margin trading or synthetic assets, against trading pools supplied by liquidity providers, tooled to automatically hedge their exposure on traditional financial market.\r\n\r\nThe Jarvis Reward Token (JRT) allows to participate in the governance of protocols, to ensure the safety of their oracles and collecting the commissions they generate.",
+        "categories": ["defi", "protocol", "reward", "governance"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x8a9c67fee641579deba04928c4bc45f66e26343a"
@@ -4812,6 +4912,7 @@
       "extensions": {
         "link": "https://akropolis.io",
         "description": "As a project, Akropolis mission is to give people the tools to save, grow and provision for the future safely and without dependence on a geography, a central counterparty, or falling prey to predatorial financial practices of multiple intermediaries.\r\n\r\nWith that in mind, Akropolis has built AkropolisOS, light and modular framework for creating for-profit DAOs, with customisable user incentives, automated liquidity provision enabled by the bonding curve mechanism, and programmatic liquidity and treasury management.\r\n\r\nOur first product, Sparta, allows taking undercollateralized loans (borrower provides only 50% of collateral), as well as to passively generate yield via integrated yield rebalancer to get maximum available APR from different DeFi protocols. All funds are pooled, and the internal economy is based on a bonding curve, which provides additional incentives to the users.\r\n\r\nOur second product is Delphi, a yield farming aggregator with dollar cost averaging tooling. Delphi ...",
+        "categories": ["defi", "protocol", "staking", "reward"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7"
@@ -4827,6 +4928,7 @@
       "extensions": {
         "link": "https://clintex.io",
         "description": "Clinical Trials Intelligence (CTi) is a scalable blockchain platform built for clinical trials, to serve as a single source of truth for the clinical trial and pharma industry and designed for wide adoption by the stakeholders of the ecosystem. CTi has been designed to transform the medicine development industry through the application of predictive analytics, machine learning, and the novel use of blockchain technology and smart contracts in clinical trials.",
+        "categories": ["rwa", "defi", "protocol", "access"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x8c18d6a985ef69744b9d57248a45c0861874f244"
@@ -4842,6 +4944,7 @@
       "extensions": {
         "link": "https://paidnetwork.com/",
         "description": "PAID Network is a business toolkit for all your needs, encompassing SMART Agreements, escrow, reputation-scoring, dispute arbitration and resolution, as well as DeFi tools such as insurance, borrowing and lending. PAID aims to take the lawyers out of legal contracts, making simple, easy-to-use SMART Agreements available for users. Reputation-scoring tracks user behavior, while escrow and dispute arbitration/resolution ensure PAID users receive the value stipulated in their contract. DeFi tools work in concert with the aforementioned elements to provide a one-stop solution for conducting business transactions.",
+        "categories": ["defi", "protocol", "access", "governance"],
         "ogImage": "https://paidnetwork.com/wp-content/uploads/2020/09/polkadot.png",
         "originChainId": 1,
         "originAddress": "0x8c8687fc965593dfb2f0b4eaefd55e9d8df348df"
@@ -4857,6 +4960,7 @@
       "extensions": {
         "link": "https://www.swipe.io/",
         "description": "The Swipe Wallet has been designed to require Swipe Tokens SXP to perform all functions and utility of the Wallet including to use the services and to make withdraws. Users on the Swipe Wallet can buy, sell, and pay with their cryptocurrencies to fiat directly within the Wallet application as well as purchase Gift Cards and make instant exchanges between all supported assets. Users are able to use their SXP tokens on launch and there are also tiered benefits based on the SXP holding on the Wallet Contract. All Swipe Wallets require a 1 SXP deposit to activate and utilize on-chain functions based on an audited Smart Wallet-Contract to perform its duties. The protocol has been designed and built on Ethereum and destroys 80% of network and transaction fees are and 20% of the fees are retained by the company.",
+        "categories": ["transactional", "defi", "access", "protocol"],
         "ogImage": "https://swipe.io/images/featured_logo.png",
         "originChainId": 1,
         "originAddress": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9"
@@ -4872,6 +4976,7 @@
       "extensions": {
         "link": "https://tbtc.network/",
         "description": "Deposit and redeem BTC in DeFi without intermediaries.",
+        "categories": ["wrapped", "defi", "protocol", "transactional"],
         "ogImage": "https://tbtc.networkundefined",
         "originChainId": 1,
         "originAddress": "0x8daebade922df735c38c80c7ebd708af50815faa"
@@ -4887,6 +4992,7 @@
       "extensions": {
         "link": "https://xhumanity.org/",
         "description": "xHumanity is a new application based on blockchain technology that supports community building and social cross-interaction, peer-to-peer in both online and offline environments, including the most widely used social media platforms.",
+        "categories": ["rwa", "privacy", "defi", "access"],
         "ogImage": "https://xhumanity.org/wp-content/uploads/2020/11/Site-1024x341.png",
         "originChainId": 1,
         "originAddress": "0x8e57c27761ebbd381b0f9d09bb92ceb51a358abb"
@@ -4902,6 +5008,7 @@
       "extensions": {
         "link": "https://www.paxos.com/standard/",
         "description": "Paxos Standard (PAX) was created by Paxos, a financial technology company on a mission to modernize finance by mobilizing assets at the speed of the internet. Paxos was the first virtual currency company to receive a charter from the New York State Department of Financial Services. As a chartered limited purpose trust company with fiduciary powers under the Banking Law, Paxos is able to offer regulated services in the crypto-asset and virtual commodities space.\r\n\r\nThe Paxos team comes from a wide variety of backgrounds with a diverse array of experiences ranging from Wall Street to Silicon Valley. It’s led by CEO and co-founder Charles Cascarilla, who has spent his career as a customer, analyst, investor and now creator of financial technology.\r\n\r\nPaxos describes itself as “the first regulated Trust company with blockchain expertise”, and it is using that expertise to create a modern settlement solution that can eliminate risk and simplify settlements. What many people may not know ...",
+        "categories": ["usd-stablecoin", "transactional", "defi", "protocol"],
         "ogImage": "https://www.paxos.com/wp-content/uploads/2019/02/peer-to-peer.png",
         "originChainId": 1,
         "originAddress": "0x8e870d67f660d95d5be530380d0ec0bd388289e1"
@@ -4917,6 +5024,7 @@
       "extensions": {
         "link": "https://singularitynet.io/",
         "description": "SingularityNET is a decentralized marketplace for Artificial Intelligence (AI). The business value of AI is becoming clearer each day; however, there’s a significant gap between the people developing AI tools (researchers and academics) and the businesses that want to use them. Most organizations need a more customized solution than what a single AI project can offer, and research projects oftentimes have trouble accessing a large enough data set to build effective machine learning. SingularityNET closes these gaps.\r\n\r\nThe long-term vision of the SingulairtyNET team is to build a network of complex AI Agent interactions primarily using resources from the OpenCog Foundation. To look at this further, let’s check out their in-house built humanoid robot, Sophia. Sophia uses a combination of AI Agents that range from natural language processing to physical motor controls to operate. You tell Sophia to summarize a video that’s embedded in a webpage. To do this, Sophia sends a request to A...",
+        "categories": ["ai", "defi", "protocol", "infrastructure"],
         "ogImage": "https://singularitynet.io/assets/images/og/Snet-Logo.png",
         "originChainId": 1,
         "originAddress": "0x8eb24319393716668d768dcec29356ae9cffe285"
@@ -4932,6 +5040,7 @@
       "extensions": {
         "link": "https://tixl.org/",
         "description": "The Hamburg/Germany based Tixl organisation is founded and managed by an experienced team building the interoperable Tixl Ecosystem for Decentralised Finance (DeFi) products.\r\n\r\nAt the core of the ecosystem is a layer 1 platform called “Autobahn Network” which serves as a base platform allowing to transfer any digital asset instantly, with almost zero fees and even with AML-compliant privacy for authorised service providers.\r\n\r\nThis proprietary technology with its benefits can be utilised for any DeFi use case. The first main DeFi product using it will be the Tixl Exchange, a scalable swap exchange for BTC, ETH and other assets launched by Tixl in December 2020.",
+        "categories": ["privacy", "transactional", "defi", "protocol"],
         "ogImage": "https://tixl.org/images/og-v7.jpg",
         "originChainId": 1,
         "originAddress": "0x8eef5a82e6aa222a60f009ac18c24ee12dbf4b41"
@@ -4947,6 +5056,7 @@
       "extensions": {
         "link": "https://dokidoki.finance/",
         "description": "AZUKI is a secondary token designed for use in Doki Doki NFT products",
+        "categories": ["meme", "defi", "reward", "access", "art"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x910524678c0b1b23ffb9285a81f99c29c11cbaed"
@@ -4962,6 +5072,7 @@
       "extensions": {
         "link": "https://whale.me/",
         "description": "$WHALE is a social currency (cryptocurrency) that is backed by tangible and rare Non-Fungible Token (NFT) assets, while embodying scarcity through definitive limited issuance. $WHALE aims to be a tangible asset backed currency, with one dimension of the token value ascribed to it's \"VAULT\" contents of digital art and collectibles. The full value proposition WHALE is descibed by the team as encompassing: 1. The Vault; 2. The Brand; 3. The Community; 4. Leadership; and 5. Tokenomics. Noteably, the token is currently transitioning to a DAO structure, whereby the community will have full control of the $WHALE assets and revenue generation streams.",
+        "categories": ["art", "defi", "reward", "access"],
         "ogImage": "https://whale.me/wp-content/uploads/2020/05/adventure-conifer-daylight-desert-302271.jpg",
         "originChainId": 1,
         "originAddress": "0x9355372396e3f6daf13359b7b607a3374cc638e0"
@@ -4977,6 +5088,7 @@
       "extensions": {
         "link": "https://kleros.io",
         "description": "Kleros is a blockchain Dispute Resolution Layer that provides fast, secure and affordable arbitration for virtually everything.\r\n\r\nKleros uses blockchain and crowdsourced specialists to adjudicate disputes in a fast, secure and affordable way. Kleros connects users who need to solve disputes with jurors who have the right skills to solve them. Crowdsourcing taps into a global pool of jurors. Blockchain technology guarantees evidence integrity, transparency in jury selection and incentives for honest rulings",
+        "categories": ["governance", "defi", "protocol", "access"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d"
@@ -4992,6 +5104,7 @@
       "extensions": {
         "link": "https://darwinia.network/",
         "description": "Darwinia Network provides developers the scalability, cross-chain interoperability, and NFT identifiability, with seamless integrations to Polkadot, bridges to all major blockchains, and on-chain RNG services",
+        "categories": ["infrastructure", "chain", "defi", "protocol"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x9469d013805bffb7d3debe5e7839237e535ec483"
@@ -5007,6 +5120,7 @@
       "extensions": {
         "link": "https://cryptotipsfriends.com/",
         "description": null,
+        "categories": ["defi", "reward", "access"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x94ca37d108e89775dc8ae65f51ae28c2d9599f9a"
@@ -5022,6 +5136,7 @@
       "extensions": {
         "link": "https://cardstack.com/",
         "description": "Cardstack is an open-source framework and consensus protocol that makes blockchains usable and scalable for the mass market, creating a decentralized software ecosystem that can challenge today’s digital superpowers. Cardstack Token (CARD) is a utility token allowing end- users and businesses to use applications that interact with multiple blockchains, decentralized protocols, app-coin-backed dApps, and cloud- based services while paying a single on-chain transaction fee. \r\n\r\nThe main value proposition of the Cardstack ICO is to breakdown the user experience of disparate software, cloud and blockchain silos which now exist on various levels of the digital world, allowing both developers and users to engage in customizable workflows. To overcome these disparate app silos, Cardstack offers a new UI, deployed via the web or as a peer-to-peer app, which turns each service created by open-source developers into a “card”. Each card comprises a visual embodiment of key information, whereby...",
+        "categories": ["infrastructure", "defi", "protocol", "access"],
         "ogImage": "https://resources.cardstack.com/images/og-e845fe761dd6e7347f657851fa300831.png",
         "originChainId": 1,
         "originAddress": "0x954b890704693af242613edef1b603825afcd708"
@@ -5037,6 +5152,7 @@
       "extensions": {
         "link": "https://shibatoken.com/",
         "description": null,
+        "categories": ["meme", "access"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce"
@@ -5052,6 +5168,7 @@
       "extensions": {
         "link": "https://app.tryroll.com/token/FIRST",
         "description": "Hello! If you made it here by chance or by invite, welcome! Access to $First will be access to behind the scene music sessions that contributed to my success today with artist I love to create with. Also this currency can grant you access to others within my network\r\n",
+        "categories": ["art", "reward"],
         "ogImage": "https://roll-token.s3.amazonaws.com/FIRST/cc2016f6-0c74-4a95-b89b-b1684c7b9426",
         "originChainId": 1,
         "originAddress": "0x9903a4cd589da8e434f264deafc406836418578e"
@@ -5067,6 +5184,7 @@
       "extensions": {
         "link": "https://strongblock.io/",
         "description": "Governance Token for StrongBlock DeFi platform.",
+        "categories": ["defi", "protocol", "reward", "staking", "infrastructure"],
         "ogImage": "https://strongblock.com/images/SB-Logo-Full.png",
         "originChainId": 1,
         "originAddress": "0x990f341946a3fdb507ae7e52d17851b87168017c"
@@ -5082,6 +5200,7 @@
       "extensions": {
         "link": "https://www.polymath.network/",
         "description": "Polymath simplifies the legal process of creating and selling security tokens. It makes a new token standard, the ST20, and enforces government compliance. Only a “list of authorized investors and their <a href=\"https://www.coingecko.com/en/coins/ethereum\">Ethereum</a> wallet addresses” can hold ST20 tokens. Therefore, token issuers don’t need to worry about the legal implications of your security falling into the wrong hands. In order to launch a legally compliant token, the Polymath platform brings together issuers, legal delegates, smart contract developers, KYC verification, and a decentralized exchange. All transactions on the Polymath platform take place using the native POLY token.\r\n\r\nPolymath has programmable equity. Polymath enables companies to take control of their equity issuance through programmable code. It is raising in cryptocurrency opens up an entire wealth of new investors. Polymath eliminates the middleman and financial structures that hinder the deployment of eq...",
+        "categories": ["rwa", "defi", "infrastructure", "protocol"],
         "ogImage": "https://uploads-ssl.webflow.com/5d2ccf16358ee969a317e33d/5f2d610575bc27251684c144_Image%20Meta%20Tag.png",
         "originChainId": 1,
         "originAddress": "0x9992ec3cf6a55b00978cddf2b27bc6882d88d1ec"
@@ -5097,6 +5216,7 @@
       "extensions": {
         "link": "https://acbtc.fi",
         "description": "acBTC is a composite asset backed by a basket of ERC20 BTC. The acBTC ecosystem integrates native BTC and ERC20 BTC, with swap, lending and yield generating applications into one highly secure, efficient and usable standard.\r\n\r\nThe AC token serves as the fundamental driver for community governance by incentivizing stakeholders for participation and sound decision making. Ecosystem incentives are designed to compensate users and Governors for their efforts on driving growth, stability and sustainability of the acBTC ecosystem.",
+        "categories": ["defi", "protocol", "reward", "bridged"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x9a0aba393aac4dfbff4333b06c407458002c6183"
@@ -5112,6 +5232,7 @@
       "extensions": {
         "link": "https://shopping.io/",
         "description": "Order from Amazon, Walmart and eBay without the hassle of opening accounts there. And you don’t have to worry about your type of coin not being accepted, or about exchange rates and other complicated steps. We handle it all for you, so it is a one-stop, one-step shopping experience. We’ve made it as simple as possible for you.\r\n\r\nSearch, shop, and pay with your favorite coins – all from one place!\r\n\r\nIf you want to get even more for your coins, you can become a Token Holder and get 15% off on every purchase you make through Shopping.io.\r\nAn added bonus? All items have free shipping for Amazon and eBay. We also offer international shipping to our Token Holders, as well. You can pay with over 100 different coins.",
+        "categories": ["defi", "transactional", "access", "reward"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x9b02dd390a603add5c07f9fd9175b7dabe8d63b7"
@@ -5127,6 +5248,7 @@
       "extensions": {
         "link": "https://www.dogefi.army/",
         "description": null,
+        "categories": ["meme", "defi", "staking", "reward"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x9b9087756eca997c5d595c840263001c9a26646d"
@@ -5142,6 +5264,7 @@
       "extensions": {
         "link": "https://coreto.io",
         "description": "Decentralized reputation-based platform  that adds a new trust layer to interactions between investors, influencers, traders, pools and project teams",
+        "categories": ["infrastructure", "access", "defi", "reward"],
         "ogImage": "https://coreto.io/images/public/facebook.png",
         "originChainId": 1,
         "originAddress": "0x9c2dc0c3cc2badde84b0025cf4df1c5af288d835"
@@ -5157,6 +5280,7 @@
       "extensions": {
         "link": "https://dokidoki.finance",
         "description": null,
+        "categories": ["defi", "protocol", "staking", "reward"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x9ceb84f92a0561fa3cc4132ab9c0b76a59787544"
@@ -5172,6 +5296,7 @@
       "extensions": {
         "link": "https://polyswarm.io/",
         "description": "PolySwarm in 60 Seconds.\r\nPolyswarm is a decentralized threat intelligence market made possible by Ethereum smart contracts and blockchain technology.\r\n\r\nPolyswarm incentivizes rapid innovation in the $8.5B/yr anti-virus and automated cyber threat intelligence space with precise economic incentives that reward timely and accurate threat intelligence concerning the malintent of files, network traffic and URLs.\r\n\r\nPolySwarm defines a real-time threat detection ecosystem involving enterprises, consumers, vendors and geographically-diverse security experts. Experts develop and hone competing “micro-engines” that autonomously investigate the latest threats, attempting to outperform their competition. PolySwarm’s “Proof of Work” is threat detection accuracy: the market rewards experts who are best able to defend enterprises and end users.\r\n\r\nRelative to today’s ad hoc market, PolySwarm will lower the barier to entry, provide broader coverage options, discourage duplicative effort and ensu...",
+        "categories": ["privacy", "defi", "protocol", "access"],
         "ogImage": "https://polyswarm.io/assets/images/social/twitter-card.png",
         "originChainId": 1,
         "originAddress": "0x9e46a38f5daabe8683e10793b06749eef7d733d1"
@@ -5187,6 +5312,7 @@
       "extensions": {
         "link": "https://darwinia.network/",
         "description": "KTON is essentially a derivative token of RING，which encourages long-term lock and commitment. RING staking participants can lock RING for 3–36 months and get KTON as rewards, compensating for the liquidity loss.",
+        "categories": ["defi", "protocol", "staking", "reward"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x9f284e1337a815fe77d2ff4ae46544645b20c5ff"
@@ -5202,6 +5328,7 @@
       "extensions": {
         "link": "https://makerdao.com/",
         "description": "MKR is a cryptocurrency depicted as a smart contract platform and works alongside the Dai coin and aims to act as a hedge currency that provides traders with a stable alternative to the majority of coins currently available on the market. Maker offers a transparent stablecoin system that is fully inspectable on the Ethereum blockchain. Founded almost three years ago, MakerDao is lead by Rune Christensen, its CEO and founder. Maker’s MKR coin is a recent entrant to the market and is not a well known project. However, after today it will be known by many more people after blowing up 40% and it is one of the coins to rise to prominence during the recent peaks and troughs.\r\n\r\nAfter being developed by the MakerDAO team, Maker Dai officially went live on December 18th, 2017. Dai is a price stable coin that is suitable for payments, savings, or collateral and provides cryptocurrency traders with increased options concerning opening and closing positions. Dai lives completely on the blockch...",
+        "categories": ["defi", "protocol", "governance", "lending"],
         "ogImage": "https://makerdao.com/dai.png",
         "originChainId": 1,
         "originAddress": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2"
@@ -5217,6 +5344,7 @@
       "extensions": {
         "link": "https://www.bittoken.club/",
         "description": "BITT is an ERC20 token built to reward holders and community members through fun and unique utility. BITT is constantly evolving to further benefit holders. Investors can earn rewards by interacting with BITT social platforms, as well as holding, staking, and spending BITT. Holders also receive discounts on branded BITT tools such as the Bitswap DEX aggregator and exchange. BITT's deflationary instrument is activated whenever BITT is used to purchase an NFT on the Bitswap platform. The project seeks to be inclusive of all members of the diverse crypto space through social integrations. Existing communities can incorporate BITT into their Discord or Telegram servers with the TIP.CC bot.",
+        "categories": ["defi", "reward", "access", "meme"],
         "ogImage": "https://secureservercdn.net/160.153.137.99/ez9.333.myftpupload.com/wp-content/uploads/2020/12/Discord-header-3-1024x576.png",
         "originChainId": 1,
         "originAddress": "0x9f9913853f749b3fe6d6d4e16a1cc3c1656b6d51"
@@ -5232,6 +5360,7 @@
       "extensions": {
         "link": "https://harvest.finance/",
         "description": "Harvest automatically farms the highest yields in DeFi\r\n\r\n",
+        "categories": ["defi", "protocol", "reward", "staking"],
         "ogImage": "/preview.png",
         "originChainId": 1,
         "originAddress": "0xa0246c9032bc3a600820415ae600c6388619a14d"
@@ -5247,6 +5376,7 @@
       "extensions": {
         "link": "https://www.crypto.com/en/chain",
         "description": "We propose Crypto.com Chain, the next generation decentralized mobile payment protocol, the most efficient and secure way to pay and be paid in crypto, anywhere, any crypto\r\nwithout fees. Crypto.com Chain will deliver on its vision by developing innovative technology components and processes (inc. scalable encryption algorithm to protect users’ privacy, utilizing trusted execution environments, sustainable price stability mechanisms, user protection via PoGSD) catered specifically to cryptocurrency payment, while leveraging proven blockchain technology structural design elements. ",
+        "categories": ["exchange", "defi", "access", "reward"],
         "ogImage": "https://chain.crypto.com/crypto-com-chain.png",
         "originChainId": 1,
         "originAddress": "0xa0b73e1ff0b80914ab6fe0444e65848c4c34450b"
@@ -5262,6 +5392,7 @@
       "extensions": {
         "link": "https://www.wrappered.com/",
         "description": "Wrapped Gen 0 (WG0) is an ERC20 token backed 1:1 by an ERC721 Generation 0 CryptoKitty.",
+        "categories": ["wrapped", "art", "defi", "access"],
         "ogImage": "images/og-image.jpg",
         "originChainId": 1,
         "originAddress": "0xa10740ff9ff6852eac84cdcff9184e1d6d27c057"
@@ -5277,6 +5408,7 @@
       "extensions": {
         "link": "https://aragon.org/",
         "description": "Aragon is a decentralized app (dApp) on the <a href=\"https://www.coingecko.com/en/coins/ethereum\">Ethereum</a> blockchain that allows anyone to create and manage a decentralized organization. The Aragon project is open source and led by the Aragon Foundation. It also includes a token, ANT, that grants voting rights to make decisions about the direction of future development. Eventually, Aragon hopes to be a fully decentralized autonomous organization and dApp that’s a neutral jurisdiction for anyone to create an organization on the blockchain. \r\n\r\nIn the early days of development, the project is relying on the nonprofit Aragon Foundation to provide direction and support as the project gets off the ground. The idea, however, is to eventually dissolve, scale back, or change the nature of the Foundation as community support grows. In the future, Aragon will be entirely decentralized and community led. Holders of the ANT token will have voting rights on all issues concerning Aragon. Ara...",
+        "categories": ["governance", "defi", "protocol", "access"],
         "ogImage": "https://assets.website-files.com/5e997428d0f2eb13a90aec8c/5ed61d34e1889f62b526d50e_Frame%201.png",
         "originChainId": 1,
         "originAddress": "0xa117000000f279d81a1d3cc75430faa017fa5a2e"
@@ -5292,6 +5424,7 @@
       "extensions": {
         "link": "https://drcglobal.org/",
         "description": "Digital Reserve Currency was designed to become a decentralized digital store of value with a limited supply and a zero inflation rate. It was created during the COVID-19 crisis when fiscal and monetary policies have exposed serious vulnerabilities in the current financial system. The concept of Digital Reserve Currency was developed by Maxim Nurov, founder of Digital Finance, Washington, DC, financial company that specializes exclusively in the digital assets space.\r\n\r\n100% of the DRC token supply has been listed on the Uniswap decentralized exchange with an intentionally small market cap to allow early adopters to establish inexpensive exposure to DRC if they believe it will have a larger market in the future. The token is fully developed and operational and its holders are immediately able to use it for its intended functionality on the Ethereum blockchain. No one has control over DRC nor provides essential managerial efforts that affect its success as DRC has fully decentralized...",
+        "categories": ["defi", "value", "transactional"],
         "ogImage": "https://drcglobal.org/static/social-share-8033d948c35326afc0f63b8c4194158f.png",
         "originChainId": 1,
         "originAddress": "0xa150db9b1fa65b44799d4dd949d922c0a33ee606"
@@ -5307,6 +5440,7 @@
       "extensions": {
         "link": "https://pundix.com",
         "description": "Pundi X is the project that wants to make spending crypto as easy as a credit card. Creators of the NPXS token hope that it will one day be used on their <a href=\"https://www.coingecko.com/en/coins/ethereum\">Ethereum</a>-based Point-of-Sale devices. This approach could give basic banking services to underdeveloped regions like Latin America and  Indonesia. One of the most notorious pain points in crypto is the ability to actually make purchases. Pundi X cryptocurrency plans to change all that by distributing hundreds to thousands of point-of-sale smart devices to retailers so they can accept payment in the form of NPXS, the network’s proprietary crypto token. If it can distribute the devices for free and with lower transaction fees than current card and mobile payment solutions provide, it’s a grand-slam idea.\r\n\r\nPundi X raised $35 million during its ICO from September 2017 through January 21, 2018. 35,000,000,000 NPXS (at the time known as PXS) were sold during the ICO presale and ...",
+        "categories": ["transactional", "defi", "access"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0xa15c7ebe1f07caf6bff097d8a589fb8ac49ae5b3"
@@ -5322,6 +5456,7 @@
       "extensions": {
         "link": "https://dfi.money/",
         "description": "YFII is a fork of YFI project with YIP-8 implementation",
+        "categories": ["defi", "protocol", "reward", "staking"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83"
@@ -5337,6 +5472,7 @@
       "extensions": {
         "link": "https://redfoxlabs.io/",
         "description": "Southeast Asia’s first blockchain Venture Builder. We innovate with blockchain technology to build market leading companies in emerging markets",
+        "categories": ["defi", "gaming", "access", "reward"],
         "ogImage": "https://lirp-cdn.multiscreensite.com/53e775e3/dms3rep/multi/opt/redfoxlabs-icon-fav-1920w.png",
         "originChainId": 1,
         "originAddress": "0xa1d6df714f91debf4e0802a542e13067f31b8262"
@@ -5352,6 +5488,7 @@
       "extensions": {
         "link": "https://alphafinance.io/",
         "description": "Alpha Finance Lab is focused on researching and building in the Decentralized Finance (DeFi) space. Alpha Lending, the first product built by Alpha Finance Lab, is a decentralized lending protocol with algorithmically adjusted interest rates built on Binance Smart Chain.\r\n\r\n\r\n",
+        "categories": ["defi", "protocol", "staking", "lending"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0xa1faa113cbe53436df28ff0aee54275c13b40975"
@@ -5363,6 +5500,7 @@
       "name": "Old Test Dai (dev)",
       "extensions": {
         "blacklist": true
+        "categories": ["usd-stablecoin", "transactional", "defi", "maker"],
       }
     },
     {
@@ -5370,7 +5508,8 @@
       "address": "0x9400294c78F7Dd244F4b5af6DfFF6C971d25aD86",
       "name": "Old Test Dai (stg)",
       "extensions": {
-        "blacklist": true
+        "blacklist": true,
+        "categories": ["usd-stablecoin", "transactional", "defi", "maker"]
       }
     },
     {
@@ -5378,7 +5517,8 @@
       "address": "0x81067076dcb7d3168ccf7036117b9d72051205e2",
       "name": "SC DxDex.io",
       "extensions": {
-        "blacklist": true
+        "blacklist": true,
+        "categories": ["exchange", "defi"]
       }
     },
     {
@@ -5386,7 +5526,8 @@
       "address": "0x647a337036b448Bed2fF75f27789A73f6Ff56f3f",
       "name": "BuyItUp",
       "extensions": {
-        "blacklist": true
+        "blacklist": true,
+        "categories": ["access"]
       }
     },
     {
@@ -5394,7 +5535,8 @@
       "address": "0x5b56A425F8b45D82EBB57dcA4F02528409ae763B",
       "name": "JustForFun",
       "extensions": {
-        "blacklist": true
+        "blacklist": true,
+        "categories": ["access"]
       }
     },
     {
@@ -5402,7 +5544,8 @@
       "address": "0x9E2d266D6c90F6C0D80a88159b15958f7135B8Af",
       "name": "StakeShare",
       "extensions": {
-        "blacklist": true
+        "blacklist": true,
+        "categories": ["access", "staking", "reward"]
       }
     },
     {
@@ -5410,7 +5553,8 @@
       "address": "0xeCDFf6Fd2f184f8B8987682A10Aa6890ca74c5A8",
       "name": "minereum",
       "extensions": {
-        "blacklist": true
+        "blacklist": true,
+        "categories": ["access"]
       }
     },
     {
@@ -5418,7 +5562,8 @@
       "address": "0x0b91b07beb67333225a5ba0259d55aee10e3a578",
       "name": "Minereum Polygon",
       "extensions": {
-        "blacklist": true
+        "blacklist": true,
+        "categories": ["access"]
       }
     },
     {
@@ -5431,6 +5576,7 @@
       "extensions": {
         "link": "https://decentral.games/",
         "description": "We build games that reward you to play. Play, earn, and scale your own metaverse guild. ICE Poker beta is now live.",
+        "categories": ["gaming", "casino", "defi", "reward"],
         "ogImage": null
       }
     },
@@ -5444,6 +5590,7 @@
       "extensions": {
         "link": "https://decentral.games/",
         "description": "We build games that reward you to play. Play, earn, and scale your own metaverse guild. ICE Poker beta is now live.",
+        "categories": ["governance", "defi", "protocol", "gaming"],
         "ogImage": null
       }
     },
@@ -5457,6 +5604,7 @@
       "extensions": {
         "link": "https://decentral.games/",
         "description": "We build games that reward you to play. Play, earn, and scale your own metaverse guild. ICE Poker beta is now live.",
+        "categories": ["gaming", "casino", "reward", "defi"],
         "ogImage": null
       }
     },
@@ -5470,6 +5618,7 @@
       "extensions": {
         "link": "https://sunflower-land.com/ ",
         "description": "Farm, Gather, Cook, Raise Animals, Fish, Craft & Trade your NFTs in this RPG based farming simulator",
+        "categories": ["gaming", "defi", "reward", "p2e", "strategy", "simulation"],
         "ogImage": null
       }
     },
@@ -5483,6 +5632,7 @@
       "extensions": {
         "link": "https://xaya.io/",
         "description": null,
+        "categories": ["gaming", "defi", "protocol", "infrastructure"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x6DC02164d75651758aC74435806093E421b64605"
@@ -5498,6 +5648,7 @@
       "extensions": {
         "link": "https://www.realfevr.com/fevr",
         "description": "RealFevr is a company established in 2015 in the fantasy markets with a football fantasy leagues game that currently has over 2 Million downloads on iOS and Android. With the fantasy leagues concept proven, RealFevr is now working towards being one of the NFT industry leaders by having the first-ever fully licensed Football Video NFTs Marketplace. Its NFTs will also be integrated into the FEVR Battle Arena, a new trading moments game (Play and Earn) that’s currently in its alpha testing stage.",
+        "categories": ["gaming", "art", "defi", "reward"],
         "ogImage": null,
         "originChainId": 56,
         "originAddress": "0x82030cdbd9e4b7c5bb0b811a61da6360d69449cc"
@@ -5513,7 +5664,8 @@
       "logoURI": "https://assets.coingecko.com/coins/images/17995/small/LS_wolfDen_logo.0025_Light_200x200.png?1665110310",
       "extensions": {
         "link": "https://guardfdn.com/",
-        "description": "Guardian is for purpose driven companies and projects building and contributing to the web3 economy."
+        "description": "Guardian is for purpose driven companies and projects building and contributing to the web3 economy.",
+        "categories": ["defi", "protocol", "access", "reward"]
       }
     },
     {
@@ -5526,6 +5678,7 @@
       "extensions": {
         "link": "https://yesports.gg/",
         "description": "YESP is a fully stacked utility token that powers engagement on the Yesports platform. The YESP token will offer access to vote in the Yesports governance and a range of stake-to-engage features to unlock deeper levels of engagement on the platform such as: exclusive access to drops and access to gamified digital experiences.",
+        "categories": ["gaming", "sports", "defi", "reward", "access", "staking"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x46ccA329970B33e1a007DD4ef0594A1cedb3E72a"
@@ -5541,6 +5694,7 @@
       "extensions": {
         "link": "https://www.glodollar.org/",
         "description": "Glo Dollar is US regulated and 1:1 backed by a reserve of cash and US Treasuries. When the Glo Foundation receives revenue from the reserve, we donate it to GiveDirectly’s basic income programs that lift people out of extreme poverty.",
+        "categories": ["usd-stablecoin", "transactional", "defi"],
         "ogImage": null
       }
     },
@@ -5552,7 +5706,8 @@
       "decimals": 2,
       "extensions": {
         "link": "https://www.boomland.io/",
-        "description": "BoomLand is Blockchain game developer and publisher with its own NFT marketplace and decentralized ecosystem. Our mission is to push the mass adoption of Web3 gaming by targeting and onboarding traditional Web2 players. Our first game, “Hunters On-Chain”, is a mobile first, multiplayer RPG."
+        "description": "BoomLand is Blockchain game developer and publisher with its own NFT marketplace and decentralized ecosystem. Our mission is to push the mass adoption of Web3 gaming by targeting and onboarding traditional Web2 players. Our first game, “Hunters On-Chain”, is a mobile first, multiplayer RPG.",
+        "categories": ["gaming", "defi", "reward", "access"]
       }
     },
     {
@@ -5563,7 +5718,8 @@
       "decimals": 18,
       "extensions": {
         "link": "https://www.boomland.io/",
-        "description": "BoomLand is Blockchain game developer and publisher with its own NFT marketplace and decentralized ecosystem. Our mission is to push the mass adoption of Web3 gaming by targeting and onboarding traditional Web2 players. Our first game, “Hunters On-Chain”, is a mobile first, multiplayer RPG."
+        "description": "BoomLand is Blockchain game developer and publisher with its own NFT marketplace and decentralized ecosystem. Our mission is to push the mass adoption of Web3 gaming by targeting and onboarding traditional Web2 players. Our first game, “Hunters On-Chain”, is a mobile first, multiplayer RPG.",
+        "categories": ["gaming", "reward", "p2e", "defi"]
       }
     },
     {
@@ -5574,7 +5730,8 @@
       "decimals": 18,
       "extensions": {
         "link": "https://coolcats.com/",
-        "description": "Cool Cats is a global storytelling brand centered around our beloved character, Blue Cat, who was created in 2013 by our founding artist, Colin Egan. Today, Cool Cats is a rich ecosystem of captivating characters and comics, innovative games, unique merchandise, and fun animations."
+        "description": "Cool Cats is a global storytelling brand centered around our beloved character, Blue Cat, who was created in 2013 by our founding artist, Colin Egan. Today, Cool Cats is a rich ecosystem of captivating characters and comics, innovative games, unique merchandise, and fun animations.",
+        "categories": ["gaming", "defi", "reward", "access"]
       }
     },
     {
@@ -5585,7 +5742,8 @@
       "decimals": 18,
       "extensions": {
         "link": "https://www.cryptounicorns.fun/",
-        "description": "Harvest and craft magical items to level up your buildings and prepare for the impending darkness. Showcase the might of your Unicorns in thrilling PvP competitions and engaging mini-games. Unite with your tribe to conquer epic team quests and win lucrative rewards. Delight in captivating mini games, and forge powerful items to enrich your adventure. Dive into a multifaceted world of strategy, creativity, and community - embark on your unique adventure in Crypto Unicorns today!"
+        "description": "Harvest and craft magical items to level up your buildings and prepare for the impending darkness. Showcase the might of your Unicorns in thrilling PvP competitions and engaging mini-games. Unite with your tribe to conquer epic team quests and win lucrative rewards. Delight in captivating mini games, and forge powerful items to enrich your adventure. Dive into a multifaceted world of strategy, creativity, and community - embark on your unique adventure in Crypto Unicorns today!",
+        "categories": ["gaming", "defi", "reward", "access", "p2e"]
       }
     },
     {
@@ -5596,7 +5754,8 @@
       "decimals": 18,
       "extensions": {
         "link": "https://www.cryptounicorns.fun/",
-        "description": "Harvest and craft magical items to level up your buildings and prepare for the impending darkness. Showcase the might of your Unicorns in thrilling PvP competitions and engaging mini-games. Unite with your tribe to conquer epic team quests and win lucrative rewards. Delight in captivating mini games, and forge powerful items to enrich your adventure. Dive into a multifaceted world of strategy, creativity, and community - embark on your unique adventure in Crypto Unicorns today!"
+        "description": "Harvest and craft magical items to level up your buildings and prepare for the impending darkness. Showcase the might of your Unicorns in thrilling PvP competitions and engaging mini-games. Unite with your tribe to conquer epic team quests and win lucrative rewards. Delight in captivating mini games, and forge powerful items to enrich your adventure. Dive into a multifaceted world of strategy, creativity, and community - embark on your unique adventure in Crypto Unicorns today!",
+        "categories": ["gaming", "defi", "reward", "access", "p2e"]
       }
     },
     {
@@ -5606,7 +5765,8 @@
       "symbol": "AVAX",
       "decimals": 18,
       "extensions": {
-        "link": "https://www.avax.network/"
+        "link": "https://www.avax.network/",
+        "categories": ["chain", "defi", "protocol", "smart-contract", "staking", "rewards"]
       }
     },
     {
@@ -5615,7 +5775,11 @@
       "name": "Alongside Crypto Market Index (PoS)",
       "type": "ERC20",
       "symbol": "AMKT",
-      "decimals": 18
+      "decimals": 18,
+      "extensions": {
+        "link": "https://www.avax.network/",
+        "categories": ["defi", "protocol", "value"]
+      }
     },
     {
       "chainId": 137,
@@ -5627,6 +5791,7 @@
       "extensions": {
         "link": "https://www.synergyland.live/",
         "description": "Synergy Land is an Action RPG game that integrates MOBA mechanics into a player-driven world that allows players real ownership of digital game assets, set in a fantasy world divided into four ecosystems: earth, water, fire and ice.",
+        "categories": ["gaming", "defi", "reward", "p2e", "strategy", "fantasy"],
         "ogImage": "https://static.wixstatic.com/media/0d5f0c_78495f1eb1dc4cda951e360be810acc7~mv2.jpg/v1/fill/w_2049,h_1736,al_c,q_90,enc_auto/0d5f0c_78495f1eb1dc4cda951e360be810acc7~mv2.jpg"
       }
     },
@@ -5640,6 +5805,7 @@
       "extensions": {
         "link": "https://www.planetmojo.io/",
         "description": "Embrace your inner Mojo and prove your strength on the battlefield!",
+        "categories": ["gaming", "defi", "reward", "p2e", "strategy"],
         "ogImage": "https://images.squarespace-cdn.com/content/v1/62bb628d44219244e9079a5a/43731023-15df-4737-a74a-209692abdd7b/planet-mojo-logo-home-splash-trimmed.png?format=1500w"
       }
     }

--- a/index/polygon/erc20.json
+++ b/index/polygon/erc20.json
@@ -530,6 +530,7 @@
       "extensions": {
         "link": "https://sushiswap.org/",
         "description": null,
+        "categories": ["exchange", "protocol", "defi"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2"
@@ -545,6 +546,7 @@
       "extensions": {
         "link": "https://www.etherlegends.io/",
         "description": "Ether Legends is focused on the seamless connection of physical and digital assets, secured by the Blockchain. The token, Elementeum is the currency that drives the game platform ecosystem (ELET).",
+        "categories": ["gaming", "access", "tcg"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x6c37bf4f042712c978a73e3fd56d1f5738dd7c43"
@@ -560,6 +562,7 @@
       "extensions": {
         "link": "https://axioms.app/",
         "description": "Axioms. Kickstart your crypto.\r\n\r\nCommunity as a Service\r\nAxioms doesn’t just create your token: it promotes it to a readymade community that’s willing to support your project.\r\n\r\n\r\n1. Take a great idea\r\nCreate your own token and build a supportive community with the whole process, from coding to deployment, fully automated.\r\n\r\n\r\n2. Tokenize it\r\nFarm it. Stake it. Tip it. Earn it. You choose the utility. We’ll program it.\r\n\r\n\r\n3. Add Axioms\r\nThe AXIOMS token powers the Axioms network, providing utility for an incentivized community.\r\n",
+        "categories": ["access", "staking"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x73ee6d7e6b203125add89320e9f343d65ec7c39a"
@@ -575,6 +578,7 @@
       "extensions": {
         "link": "https://cord.finance/",
         "description": "CORD.Finance is a project that uses a unique combination of smart contract technology plus real world networking to provide varied income streams and capital appreciation for its holders.\r\n\r\nThe worldwide team of six project leaders has a variety of expertise that collectively supports this goal. The team includes a PhD\r\nstatistician and developer with 25 years experience, tokenomics experts who understand the economics of digital assets, networking experts with international connections in such diverse areas as finance, farming, and charity, as well as both ERC20 and NFT developers. \r\n\r\nCORD.Finance runs staking pools/vaults on an ongoing basis for CORD holders (and its deflationary pairing token VACC). The CORD.Finance team actively seeks out staking partnerships with other projects, as this can provide a synergistic benefit to both projects by increasing exposure and economies of scale. \r\n\r\nOther real-world partnerships being cultivated\r\nby the CORD.Finance team include those in ...",
+        "categories": ["defi", "staking", "reward"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x74fb9da15d4f9a34d8c825798da0fa5c400dade1"
@@ -590,6 +594,7 @@
       "extensions": {
         "link": "https://aave.com/",
         "description": "Aave is a decentralized lending platform that runs on <a href=\"https://www.coingecko.com/en/coins/ethereum\">Ethereum</a> Network which offers secure, peer-to-peer lending Smart Contracts. Aave strives to break through the traditional bank loans system with a more efficient solution. Aave also uniquely allows a borrower and a lender to decide on important loan details that can eliminate the need of a middle man. Due to the elimination of middlemen, process fee for a loan does not exist on this platform. This provide convenience to any lender and borrower to create loans on their agreed terms. Decentralized lending has fixed many issues and one of the reasons why is the transparency of loan.\r\n\r\nThe Ethereum network provides a transparent ledger where all transactions are available to be inspected. Secondly, it isn’t necessary to find a trusted loan provider because all collateral which is the digital asset for loans are stored and locked in a smart contract and broadcasted on the publ...",
+        "categories": ["defi", "lending", "reward", "aave"],
         "ogImage": "https://aave.com/favicon64.png",
         "originChainId": 1,
         "originAddress": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03"
@@ -605,6 +610,7 @@
       "extensions": {
         "link": "https://www.iggalaxy.com/",
         "description": "IGG is the native token within the IGGalaxy which will power the IG esports ecosystem. The TRC20 token will fundamentally disrupt the way stakeholders within the esports landscape interact and exchange value. Coupled with smart contracts, IGG will have real world utility for gamers, teams, brands and the wider public.",
+        "categories": ["gaming", "access", "casual"],
         "ogImage": "https://www.iggalaxy.com/android-chrome-512x512.png",
         "originChainId": 1,
         "originAddress": "0x8ffe40a3d0f80c0ce6b203d5cdc1a6a86d9acaea"
@@ -620,6 +626,7 @@
       "extensions": {
         "link": "https://easyfi.network/",
         "description": "Layer 2 Defi Lending Protocol for Digital Assets",
+        "categories": ["defi", "lending", "reward", "layer2"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x913d8adf7ce6986a8cbfee5a54725d9eea4f0729"
@@ -635,6 +642,7 @@
       "extensions": {
         "link": "https://swirgepay.com/",
         "description": "Swirge is an ecosystem that embodies a decentralized social media, a decentralized financial system, and a marketplace built on the blockchain technology. Swirge ecosystem is a user-centric platform that is built with users in mind. First, to protect the user's data and information and give them total control over their data. secondly, to give users the power to create wealth by socializing and the opportunity to take charge of their finances. Our solutions offer a user-friendly social platform, and we are so proud to share it with the entire world.",
+        "categories": ["defi", "access", "transactional"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x92ef4ffbfe0df030837b65d7fccfe1abd6549579"
@@ -650,6 +658,7 @@
       "extensions": {
         "link": "https://oceanprotocol.com/",
         "description": "Ocean Protocol is an ecosystem for sharing data and associated services. It provides a tokenized service layer that exposes data, storage, compute and algorithms for consumption with a set of deterministic proofs on availability and integrity that serve as verifiable service agreements. There is staking on services to signal quality, reputation and ward against Sybil Attacks.\r\n\r\nOcean helps to unlock data, particularly for AI. It is designed for scale and uses blockchain technology that allows data to be shared and sold in a safe, secure and transparent manner.\r\n\r\nThe Ocean Protocol is an ecosystem composed of data assets and services, where assets are represented by data and algorithms, and services are represented by integration, processing and persistence mechanisms. Ocean Protocol facilitates discovery by storing and promoting metadata, linking assets and services, and provides a licensing framework that has toolsets for pricing.\r\n\r\nA multitude of data marketplaces can hook into...",
+        "categories": ["infrastructure", "staking", "ai", "reward"],
         "ogImage": "https://oceanprotocol.com/static/share-5558ae2d9f99864a95f6f99172be9768.png",
         "originChainId": 1,
         "originAddress": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48"
@@ -665,6 +674,7 @@
       "extensions": {
         "link": "https://sportx.bet/",
         "description": "SportX is a community-owned sports betting exchange and political prediction market built on the Ethereum and Matic blockchains.",
+        "categories": ["sports", "access", "defi"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x99fe3b1391503a1bc1788051347a1324bff41452"
@@ -680,6 +690,7 @@
       "extensions": {
         "link": "https://www.cometh.io/",
         "description": "A DeFi powered Blockchain game with yield generating NFT.",
+        "categories": ["gaming", "access", "defi"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x9c78ee466d6cb57a4d01fd887d2b5dfb2d46288f"
@@ -695,6 +706,7 @@
       "extensions": {
         "link": "https://www.circle.com/en/usdc",
         "description": "USDC bridged from Ethereum network.",
+        "categories": ["usd-stablecoin", "transactional", "usdc", "bridged"],
         "ogImage": "https://www.circle.com/hubfs/share-USDC.png#keepProtocol",
         "originChainId": 1,
         "originAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
@@ -710,6 +722,7 @@
       "extensions": {
         "link": "https://www.circle.com/en/usdc",
         "description": "USDC is a fully collateralized US dollar stablecoin. USDC is the bridge between dollars and trading on cryptocurrency exchanges. The technology behind CENTRE makes it possible to exchange value between people, businesses and financial institutions just like email between mail services and texts between SMS providers. We believe by removing artificial economic borders, we can create a more inclusive global economy. ",
+        "categories": ["usd-stablecoin", "transactional", "usdc"],
         "ogImage": "https://www.circle.com/hubfs/share-USDC.png#keepProtocol"
       }
     },
@@ -723,6 +736,7 @@
       "extensions": {
         "link": "https://celsius.network/",
         "description": "For crypto to continue to spread and gain traction we’ve got to bring the next 100m people into the crypto community. In order to do that, real products built by real teams have to provide real utility to the public. We’re building Celsius to bring a new wave of financial products to the market designed, for the first time, to always do what’s in the best interest of its members instead of trying to make as much profit as possible. Members will be able to borrow USD against their crypto holdings in their wallet which will be used as collateral. Our goal is to allow anyone who’s in need of cash to easily borrow from the Celsius platform without having to sell their crypto holdings. In the future, through the Celsius Network, cryptocurrencies deposited by members into their Celsius Wallet will be available on the network for immediate borrowing and shorting.\r\n\r\n",
+        "categories": ["defi", "lending", "access", "transactional"],
         "ogImage": "https://celsius.network/wp-content/uploads/2021/01/open-graph.png",
         "originChainId": 1,
         "originAddress": "0xaaaebe6fe48e54f431b0c390cfaf0b017d09d42d"
@@ -738,6 +752,7 @@
       "extensions": {
         "link": "https://0xbitcoin.org/",
         "description": "The first pure mined ERC20 Token for Ethereum, using the soliditySHA3 hashing algorithm. This is a smart contract which follows the original Satoshi Nakamoto whitepaper to form a fundamentally sound trustless currency. This combines the scarcity and fair distribution model of Bitcoin with the speed and extensibility of the Ethereum network. Thus, it is named 0xBitcoin or 0xBTC where 0x represents the Ethereum Network and ecosystem.",
+        "categories": ["infrastructure", "access", "value"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31"
@@ -753,6 +768,7 @@
       "extensions": {
         "link": "https://dust-token.com/",
         "description": "DUST is the official currency of the Mutant Universe. It can be earned by contributions to the Mutant cause and used for mining new mutants, as a payment method in NFT marketplaces or games.",
+        "categories": ["governance", "access"],
         "ogImage": "https://img1.wsimg.com/isteam/stock/12404",
         "originChainId": 1,
         "originAddress": "0xbca3c97837a39099ec3082df97e28ce91be14472"
@@ -768,6 +784,7 @@
       "extensions": {
         "link": "https://compound.finance/governance/comp",
         "description": "The Compound Governance Token is a governance token on the Compound Finance lending protocol, COMP allows the owner to delegate voting rights to the address of their choice; the owner’s wallet, another user, an application, or a DeFi expert. Anybody can participate in Compound governance by receiving delegation, without needing to own COMP.\r\n\r\nAnybody with 1% of COMP delegated to their address can propose a governance action; these are simple or complex sets of actions, such as adding support for a new asset, changing an asset’s collateral factor, changing a market’s interest rate model, or changing any other parameter or variable of the protocol that the current administrator can modify.",
+        "categories": ["governance", "defi", "lending", "access"],
         "ogImage": "https://compound.finance/images/meta-tag.png",
         "originChainId": 1,
         "originAddress": "0xc00e94cb662c3520282e6f5717214004a7f26888"
@@ -783,6 +800,7 @@
       "extensions": {
         "link": "https://www.reddit.com/r/ethtrader",
         "description": "Donuts are a form of community points that are (currently) exclusive to the r/ethtrader subreddit. You can think of them as similar to Reddit karma, except exclusively representing contributions on r/ethtrader, rather than all of Reddit.\r\n\r\nYou can also directly give Donuts to other users as a reward for good comments. Once you have Donuts, give it a try! While using the new Reddit redesign, click on the Donut symbol next to any username to give that user some of your Donuts.\r\n\r\nDonuts use cases currently include tipping other users' posts and comments, adding weight to your votes in governance polls, buying limited-edition subreddit badges, and buying the banner to probably update it with whatever weird t-shirt Vitalik wore to the last development conference.\r\n\r\nYou can also turn any amount of your Reddit Donuts into an ERC-20 cryptocurrency token at a 1:1 rate, and vice versa.\r\n\r\nConverting EthTrader Donuts To ERC-20 Donuts\r\nStep 1: Deposit donuts into your donut.dance account.\r\n\r...",
+        "categories": ["meme", "access"],
         "ogImage": "https://styles.redditmedia.com/t5_37jgj/styles/communityIcon_6fu1hyaavac61.png?width=256&s=febf72b6edbe2971e3c7eaad1cb76aa86c3075fa",
         "originChainId": 1,
         "originAddress": "0xc0f9bd5fa5698b6505f643900ffa515ea5df54a9"
@@ -798,6 +816,7 @@
       "extensions": {
         "link": "https://chaingames.io/",
         "description": "The CHAIN token is the primary medium of exchange used for all entry fees and contest payouts on the Chain Games network.",
+        "categories": ["gaming", "access", "reward", "transactional"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0xc4c2614e694cf534d407ee49f8e44d125e4681c4"
@@ -813,6 +832,7 @@
       "extensions": {
         "link": "https://etherisc.com/",
         "description": "Etherisc is building a platform for decentralized insurance applications. We aim to use blockchain technologyto help make the purchase and sale of insurance more efficient, enable lower operational costs, provide greater transparency into the industry and democratize access to reinsurance investments.\r\n\r\n",
+        "categories": ["staking", "access", "governance", "defi"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0xc719d010b63e5bbf2c0551872cd5316ed26acd83"
@@ -828,6 +848,7 @@
       "extensions": {
         "link": "https://autonio.foundation/",
         "description": "Autonio Foundation is a decentralized autonomous organization built around developing accessible, easy to use and affordable trading tools. These tools make it easier for crypto traders to conduct trading analysis, deploy trading algorithms, exchange crypto currencies, sell their strategies and pool funds for trading purposes, all with profitability, security and ease.",
+        "categories": ["transactional", "access", "governance", "defi"],
         "ogImage": "https://uploads-ssl.webflow.com/5f7b07d2864ecd2ebd67992f/5fe5e1480db7fa58fee81b9c_opengraph-autonio.png",
         "originChainId": 1,
         "originAddress": "0xc813ea5e3b48bebeedb796ab42a30c5599b01740"
@@ -843,6 +864,7 @@
       "extensions": {
         "link": "https://trustswap.org/",
         "description": "An Evolution in Defi Transactions\r\nEscrow | Time-Release | Smart Swaps | Tokens & Tokenized Assets\r\n\r\nTrustswap is an easy way for you and anyone in the world to make safe cryptocurrency transactions together.\r\n\r\nEvery transaction paid in SWAP rewards stakers and liquidity providers with 80% of the transaction fee. 10% is burned, and 10% goes to the foundation\r\n",
+        "categories": ["staking", "reward", "access", "defi"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0xcc4304a31d09258b0029ea7fe63d032f52e44efe"
@@ -858,6 +880,7 @@
       "extensions": {
         "link": "https://dontbuymeme.com",
         "description": null,
+        "categories": ["meme"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0xd5525d397898e5502075ea5e830d8914f6f0affe"
@@ -873,6 +896,7 @@
       "extensions": {
         "link": "https://tether.to/",
         "description": "Tether (USDT) is a cryptocurrency with a value meant to mirror the value of the U.S. dollar. The idea was to create a stable cryptocurrency that can be used like digital dollars. Coins that serve this purpose of being a stable dollar substitute are called “stable coins.” Tether is the most popular stable coin and even acts as a dollar replacement on many popular exchanges! According to their site, Tether converts cash into digital currency, to anchor or “tether” the value of the coin to the price of national currencies like the US dollar, the Euro, and the Yen. Like other cryptos it uses blockchain. Unlike other cryptos, it is [according to the official Tether site] “100% backed by USD” (USD is held in reserve). The primary use of Tether is that it offers some stability to the otherwise volatile crypto space and offers liquidity to exchanges who can’t deal in dollars and with banks (for example to the sometimes controversial but leading exchange <a href=\"https://www.coingecko.com/en...",
+        "categories": ["usd-stablecoin", "transactional", "usdt"],
         "ogImage": "https://tether.to/wp-content/uploads/2020/09/tether-preview.png",
         "originChainId": 1,
         "originAddress": "0xdac17f958d2ee523a2206206994597c13d831ec7"
@@ -888,6 +912,7 @@
       "extensions": {
         "link": "https://www.atarichain.com/",
         "description": "The Atari Token’s mission is to bring decentralization and universality to the video game and interactive entertainment industry. The goal of the Atari Token is to be the utility token of reference within the video game and interactive entertainment world, either as an in-game token or as a means of exchange for services or products between individuals and/or companies. Atari aims to provide participants with the tools necessary to effectively use smart contracts and smart platforms and reach mass adoption as quickly as possible. The Atari Group has recently entered into many partnership agreements to progressively develop the adoption and the use cases of the Atari Token. The Atari Token is issued by Atari Chain, Ltd (Gibraltar). For more information about the Atri Token, please visit the official Atari website.\r\n\r\nATARI Chain, Ltd, incorporated in Gibraltar, is responsible for the governance and ecosystem development of the ATARI Network of smart platforms using the ATARI Token. T...",
+        "categories": ["gaming", "transactional", "rwa", "casino"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0xdacd69347de42babfaecd09dc88958378780fb62"
@@ -903,6 +928,7 @@
       "extensions": {
         "link": "https://decentral.games",
         "description": "decentral.games is a community-owned metaverse casino ecosystem powered by $DG. Players earn $DG for playing games, LPs earn $DG for providing liquidity, and active $DG holders earn $DG by governing the allocation of house profits. ",
+        "categories": ["gaming", "staking", "reward", "governance", "casino"],
         "ogImage": "https://res.cloudinary.com/dnzambf4m/image/upload/v1607984535/feat_u522ov.png",
         "originChainId": 1,
         "originAddress": "0xee06a81a695750e71a662b51066f2c74cf4478a0"
@@ -918,6 +944,7 @@
       "extensions": {
         "link": "https://pepemon.world/",
         "description": "PPDEX is the center of Pepemon Economy, being the token PPBLZ holders can farm to mint NFTs",
+        "categories": ["meme", "exchange", "staking", "reward", "governance", "access"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0xf1f508c7c9f0d1b15a76fba564eef2d956220cf7"
@@ -933,6 +960,7 @@
       "extensions": {
         "link": "https://apy.vision",
         "description": "APY.vision is a tool to help liquidity providers with analytics. The VISION tokens unlocks pro access to the Vision suite of tools.",
+        "categories": ["access", "staking", "governance", "defi"],
         "ogImage": "https://s3-us-west-2.amazonaws.com/acf-uploads/apyvisionlogo512.png",
         "originChainId": 1,
         "originAddress": "0xf406f7a9046793267bc276908778b29563323996"
@@ -948,6 +976,7 @@
       "extensions": {
         "link": "https://amptoken.org",
         "description": "What is Amp?\r\n\r\nAmp is described as the new digital collateral token offering instant, verifiable assurances for any kind of value transfer. Using Amp, networks like Flexa can quickly and irreversibly secure transactions for a wide variety of asset-related use cases.\r\n\r\nHow does Amp work?\r\n\r\nAmp claims to offer a straightforward but versatile interface for verifiable collateralization through a system of collateral partitions and collateral managers. Where collateral partitions can be designated to collateralize any account, application, or even transaction, and carry balances which are directly verifiable on the Ethereum blockchain, collateral managers are smart contracts that can lock, release, and redirect collateral in these partitions as needed in order to support value transfer activities. Amp supports a wide variety of use cases for collateralization, and also introduces the concept of predefined partition strategies, which can enable special capabilities such as collateral m...",
+        "categories": ["transactional", "staking", "governance", "defi"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0xff20817765cb7f73d4bde2e66e067e58d11095c2"
@@ -963,6 +992,7 @@
       "extensions": {
         "link": "https://frax.finance",
         "description": "The first fractional-algorithmic stablecoin",
+        "categories": ["usd-stablecoin", "stablecoin", "lending", "protocol", "defi"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x853d955acef822db058eb8505911ed77f175b99e"
@@ -978,6 +1008,7 @@
       "extensions": {
         "link": "https://rottenswap.org/#/",
         "description": "RottenSwap, a deflationary SushiSwap fork.",
+        "categories": ["meme", "governance", "staking", "reward", "defi"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0xd04785c4d8195e4a54d9dec3a9043872875ae9e2"
@@ -993,6 +1024,7 @@
       "extensions": {
         "link": "https://weth.io/",
         "description": "W-ETH is \"wrapped ETH\" but let's start by introducing the players. First, there's Ether token. Ether or ETH is the native currency built on the Ethereum blockchain.\r\nSecond, there are alt tokens. When a dApp (decentralized app) is built off of the Ethereum Blockchain it usually implements it’s own form of Token. Think Augur’s REP Token, or Bancor's BNT Token. Finally the ERC-20 standard. ERC20 is a standard developed after the release of ETH that defines how tokens are transferred and how to keep a consistent record of those transfers among tokens in the Ethereum Network.",
+        "categories": ["defi", "protocol", "chain", "wrapped"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0xa45b966996374e9e65ab991c6fe4bfce3a56dde8"
@@ -1008,6 +1040,7 @@
       "extensions": {
         "link": "https://weth.io/",
         "description": "W-ETH is \"wrapped ETH\" but let's start by introducing the players. First, there's Ether token. Ether or ETH is the native currency built on the Ethereum blockchain.\r\nSecond, there are alt tokens. When a dApp (decentralized app) is built off of the Ethereum Blockchain it usually implements it’s own form of Token. Think Augur’s REP Token, or Bancor's BNT Token. Finally the ERC-20 standard. ERC20 is a standard developed after the release of ETH that defines how tokens are transferred and how to keep a consistent record of those transfers among tokens in the Ethereum Network.",
+        "categories": ["defi", "protocol", "chain", "wrapped"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
@@ -1023,6 +1056,7 @@
       "extensions": {
         "link": "https://www.trusttoken.com/",
         "description": "TrueUSD provides its token holders regular attestations of escrowed balances, full collateral, and also the legal protection against misappropriating underlying USD. The team believes that TrueUSD will be able to come up with the stable trading instrument for the traders of cryptocurrency that has been long-awaited. This will allow the businesses and consumers to use the digital currency as a medium of an exchange. The goal of the TrueUSD team was to build a coin that is stable and which can be used and trusted by them too. TrustToken is a platform that creates the tokens backed by assets that can easily be purchased and sold all around the world. The first asset token of TrustToken is TrueUSD, which is a stable coin and can be redeemed 1-for-1 for US dollars. TrustToken have partnered with registered fiduciaries and banks for holding the funds securely backed by TrueUSD tokens. To increase the amount of security, fiduciaries, and banks directly handle all the funds. Escrowed funds ...",
+        "categories": ["usd-stablecoin", "transactional"],
         "ogImage": "https://www.trusttoken.com/static/tt-social-card-8bccc7e39896ee3893eac90950f6a39b.png",
         "originChainId": 1,
         "originAddress": "0x0000000000085d4780b73119b644ae5ecd22b376"

--- a/index/polygon/erc20.json
+++ b/index/polygon/erc20.json
@@ -2288,6 +2288,7 @@
       "extensions": {
         "link": "https://bidaochain.com/",
         "description": "Bidao® is building a chain agnostic trustless stablecoin and decentralized finance ecosystem. Moreover the Bidao® Token can be staked to earn extra rewards.",
+        "categories": ["defi", "protocol", "stablecoin", "reward"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x25e1474170c4c0aa64fa98123bdc8db49d7802fa"
@@ -2303,6 +2304,7 @@
       "extensions": {
         "link": "https://www.moontools.io",
         "description": "MoonTools is a data explorer for decentralized exchanges. MOONS tokens are required to access different features in the MoonTools app.",
+        "categories": ["defi", "access", "infrastructure"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x260e63d91fccc499606bae3fe945c4ed1cf56a56"
@@ -2318,6 +2320,7 @@
       "extensions": {
         "link": "https://www.degen.vc/",
         "description": "\"Degens replace VCs - Curation Market for Uniswap.\r\n\r\nIn a Nutshell: Assuming teams lock their tokens in a pragmatic way, an airdrop to Uniswap liquidity providers is a viable funding strategy for a crypto project. DGVC token liquidity providers on Uniswap receive these airdrops in proportion to their LP token holding. When we get big enough degens replace VCs.\"",
+        "categories": ["defi", "reward", "meme"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x26e43759551333e57f073bb0772f50329a957b30"
@@ -2333,6 +2336,7 @@
       "extensions": {
         "link": "https://www.airswap.io/",
         "description": "AirSwap is a decentralized token exchange based on the Swap protocol whitepaper. Swap provides a decentralized trading solution based on a peer-to-peer design. The design solves two problems encountered in a peer-to-peer trading environment: counterparty discovery and pricing suggestions.",
+        "categories": ["exchange", "defi", "protocol", "transactional"],
         "ogImage": "https://www.airswap.io/airswap-ogp.png",
         "originChainId": 1,
         "originAddress": "0x27054b13b1b798b345b591a4d22e6562d47ea75a"
@@ -2348,6 +2352,7 @@
       "extensions": {
         "link": "https://www.digitalax.xyz/",
         "description": "MONA is the native ERC-20 token for the DIGITALAX platform. It is the platform's utility token and also serves as part of the platform's governance. ",
+        "categories": ["art", "defi", "protocol", "access", "governance"],
         "ogImage": "/images/favicon.png",
         "originChainId": 1,
         "originAddress": "0x275f5ad03be0fa221b4c6649b8aee09a42d9412a"
@@ -2363,6 +2368,7 @@
       "extensions": {
         "link": "https://aleph.im",
         "description": "aleph.im is a decentralized cloud storage, database and computing platform, that is compatible with blockchains and speaks their languages. It aims to be the infrastructure layer of the DeFI (decentralized finance) ecosystem.",
+        "categories": ["infrastructure", "defi", "protocol", "privacy"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x27702a26126e0b3702af63ee09ac4d1a084ef628"
@@ -2378,6 +2384,7 @@
       "extensions": {
         "link": "https://www.ousd.com",
         "description": "Origin Dollar (OUSD) is the first stablecoin that earns a yield while it's still in your wallet. Built by the team at Origin Protocol (OGN).",
+        "categories": ["usd-stablecoin", "transactional", "defi", "reward"],
         "ogImage": "https://ousd.com/images/share-facebook.png",
         "originChainId": 1,
         "originAddress": "0x2a8e1e676ec238d8a992307b495b45b3feaa5e86"
@@ -2393,6 +2400,7 @@
       "extensions": {
         "link": "https://www.bitfinex.com/",
         "description": null,
+        "categories": ["exchange", "access", "infrastructure"],
         "ogImage": "/images/thumbnails/bitfinex-1.png",
         "originChainId": 1,
         "originAddress": "0x2af5d2ad76741191d15dfe7bf6ac92d4bd912ca3"
@@ -2409,6 +2417,7 @@
         "link": "https://cream.finance/",
         "description": null,
         "ogImage": "https://cream.finance/img/og-image.jpg",
+        "categories": ["defi", "lending", "protocol", "reward"],
         "originChainId": 1,
         "originAddress": "0x2ba592f78db6436527729929aaf6c908497cb200"
       }
@@ -2423,6 +2432,7 @@
       "extensions": {
         "link": "https://www.bilira.co/",
         "description": "BiLira is a stable cryptocurrency that is backed by the Turkish Lira. This means that you can always buy and redeem 1 BiLira for ₺1.00 Turkish Lira.",
+        "categories": ["stablecoin", "transactional", "rwa"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x2c537e5624e4af88a7ae4060c022609376c8d0eb"
@@ -2438,6 +2448,7 @@
       "extensions": {
         "link": "https://agatoken.com/",
         "description": null,
+        "categories": ["defi", "reward", "access"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x2d80f5f5328fdcb6eceb7cacf5dd8aedaec94e20"
@@ -2453,6 +2464,7 @@
       "extensions": {
         "link": "https://thelitcollective.com/",
         "description": null,
+        "categories": ["gaming", "access", "reward"],
         "ogImage": "https://thelitcollective.files.wordpress.com/2020/04/picture_20200206_154444187-1.png",
         "originChainId": 1,
         "originAddress": "0x2e3c062e16c1a3a04ddc5003c62e294305d83684"
@@ -2468,6 +2480,7 @@
       "extensions": {
         "link": "https://www.FREEcoin.technology",
         "description": "The FREE coin is the ideal \"start-to-crypto\" coin : a friendly community and real world usecases. The FREE coin is circulating on the Ethereum and TRON Blockchains",
+        "categories": ["meme", "transactional", "access"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x2f141ce366a2462f02cea3d12cf93e4dca49e4fd"
@@ -2483,6 +2496,7 @@
       "extensions": {
         "link": "https://decentr.net/",
         "description": "Decentr is allows users to generate, reuse and exchange high quality data online via a secure browser/browser extension and suite of dFintech tools. \r\n\r\nDecentr’s “data-as-value” paradigm means users see a correlated decrease in the cost of products and services bought online, via Decentr and our “dPay” system, while at the same providing superior APR’s on consumer crypto loans made via users dWallet and Decentr’s consumer crypto dLoan features.  This (necessary) extension of DeFi 1.0, delivers user-centric financial services to anyone, when they want it and how they want it, regardless of their net worth.",
+        "categories": ["infrastructure", "defi", "protocol", "privacy", "access"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x30f271c9e86d2b7d00a6376cd96a1cfbd5f0b9b3"
@@ -2498,6 +2512,7 @@
       "extensions": {
         "link": "https://tokenlon.im/imBTC",
         "description": "imBTC is an Ethereum token that represents 1:1 the value of bitcoin. Holders can mint, exchange, redeem, and receive the income on imBTC from the Tokenlon platform.",
+        "categories": ["wrapped", "reward", "defi", "transactional", "protocol"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x3212b29e33587a00fb1c83346f5dbfa69a458923"
@@ -2513,6 +2528,7 @@
       "extensions": {
         "link": "https://mcp3d.com",
         "description": "Decentralized city builder game resources index.",
+        "categories": ["gaming", "defi", "reward", "access", "strategy", "simulation"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x3218a02f8f8b5c3894ce30eb255f10bcba13e654"
@@ -2528,6 +2544,7 @@
       "extensions": {
         "link": "https://n3rd.finance",
         "description": null,
+        "categories": ["defi", "protocol", "reward"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x32c868f6318d6334b2250f323d914bc2239e4eee"
@@ -2543,6 +2560,7 @@
       "extensions": {
         "link": "https://rampdefi.com/",
         "description": "Unlocking liquid capital from staked assets - Tap into cross chain liquidity and stake farming.\r\n",
+        "categories": ["defi", "staking", "reward", "access"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x33d0568941c0c64ff7e0fb4fba0b11bd37deed9f"
@@ -2558,6 +2576,7 @@
       "extensions": {
         "link": "https://frax.finance",
         "description": "The Frax Share token is the governance and value accrual token of the Frax Stablecoin Protocol",
+        "categories": ["stablecoin", "defi", "protocol", "governance"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x3432b6a60d23ca0dfca7761b7ab56459d9c964d0"
@@ -2573,6 +2592,7 @@
       "extensions": {
         "link": "https://basis.cash/",
         "description": "Fairly distributed & censorship resistant stablecoin with an algorithmic central bank",
+        "categories": ["stablecoin", "defi", "protocol"],
         "ogImage": "http://cdn-basis-cash.surge.sh/og_image.png",
         "originChainId": 1,
         "originAddress": "0x3449fc1cd036255ba1eb19d65ff4ba2b8903a69a"
@@ -2588,6 +2608,7 @@
       "extensions": {
         "link": "https://app.badger.finance/",
         "description": null,
+        "categories": ["defi", "protocol", "staking", "reward", "governance"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x3472a5a71965499acd81997a54bba8d852c6e53d"
@@ -2603,6 +2624,7 @@
       "extensions": {
         "link": "https://www.kitten.finance/",
         "description": "AlphaDEX is a DEX and part of the Kitten.Finance ecosystem.",
+        "categories": ["exchange", "defi", "protocol"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x3516415161c478df10adbb8bb884cc83fbd5f11a"
@@ -2618,6 +2640,7 @@
       "extensions": {
         "link": "https://e1337.pro/",
         "description": null,
+        "categories": ["meme", "gaming", "defi"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x35872fea6a4843facbcdbce99e3b69596a3680b8"
@@ -2633,6 +2656,7 @@
       "extensions": {
         "link": "https://www.mantradao.com/",
         "description": null,
+        "categories": ["defi", "protocol", "staking", "governance", "reward"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x3593d125a4f7849a1b059e64f4517a86dd60c95d"
@@ -2648,6 +2672,7 @@
       "extensions": {
         "link": "https://www.parsiq.net/",
         "description": "Connect blockchain activity to your apps and devices.\r\n\r\nSave hours of manual work. Reduce cost and complexity. No coding required.",
+        "categories": ["infrastructure", "defi", "access", "protocol"],
         "ogImage": "https://www.parsiq.net/soc.jpg",
         "originChainId": 1,
         "originAddress": "0x362bc847a3a9637d3af6624eec853618a43ed7d2"
@@ -2663,6 +2688,7 @@
       "extensions": {
         "link": "https://bao.finance/",
         "description": "Warning: Bao Finance is in alpha, it is unaudited and was originally developed by a one-person self-taught team. While we are in the process of scaling the team, please understand the risks and use this product accordingly.\r\n\r\nIt's like SNX + Aave, but for Uniswap, SushiSwap and Balancer.\r\n\r\nRather than re-invent the wheel Bao creates new features for existing protocols.\r\n\r\nThe BAO token acts as a governance token for the fully community run project. It is also backed by the insurance fund where all Bao fees go.",
+        "categories": ["defi", "protocol", "reward", "governance"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x374cb8c27130e2c9e04f44303f3c8351b9de61c1"
@@ -2678,6 +2704,7 @@
       "extensions": {
         "link": "https://www.sandbox.game/en/",
         "description": null,
+        "categories": ["gaming", "defi", "access", "art", "p2e", "open-world", "strategy"],
         "ogImage": "/The-Sandbox.png",
         "originChainId": 1,
         "originAddress": "0x3845badade8e6dff049820680d1f14bd3903a5d0"
@@ -2693,6 +2720,7 @@
       "extensions": {
         "link": "https://phoenixdao.io/",
         "description": "The Phoenix DAO foundation is launching a new token (PHNX) that is forked from an existing open-source community driven project, Hydro Blockchain (formally known as Project Hydro). Phoenix DAO solves the centralized issues at the core of the original Hydro project with a community built DAO, a healthier token distribution plan with built-in smart contracts, added use cases, and an updated token supply. The PHNX ecosystem includes the following protocols; Authentication, Identity, Payments, Storage, Tokenization which will be the backbone of the ecosystem fuelling the dApp Store and an Events Marketplace",
+        "categories": ["defi", "protocol", "governance", "access"],
         "ogImage": "images/home/ogg.png",
         "originChainId": 1,
         "originAddress": "0x38a2fdc11f526ddd5a607c1f251c065f40fbf2f7"
@@ -2708,6 +2736,7 @@
       "extensions": {
         "link": "https://compound.finance/",
         "description": "Compound is an open-source, autonomous protocol built for developers, to unlock a universe of new financial applications. Interest and borrowing, for the open financial system.",
+        "categories": ["usd-stablecoin", "defi", "lending", "protocol", "compound"],
         "ogImage": "https://compound.finance/images/meta-tag.png",
         "originChainId": 1,
         "originAddress": "0x39aa39c021dfbae8fac545936693ac917d5e7563"
@@ -2723,6 +2752,7 @@
       "extensions": {
         "link": "https://app.tryroll.com/token/OSINA",
         "description": "OSINA is a social currency developed around the work of Nigerian visual artist, Osinachi.",
+        "categories": ["art", "access", "reward"],
         "ogImage": "https://roll-token.s3.amazonaws.com/OSINA/59b6fcb1-c00f-49a2-bc86-431fc9041b10",
         "originChainId": 1,
         "originAddress": "0x39ad22c916f42af5f67371d6f2fb0dab42321a89"
@@ -2738,6 +2768,7 @@
       "extensions": {
         "link": "https://titanswap.org/",
         "description": "TITAN is a blockchain based decentralized financial center that provides optimal liquidity solutions for different digital asset category by adaptive bonding curve. It not only provides a user-centered decentralized exchange, but also it is an aggregated liquidity pool that supports order smart routing.",
+        "categories": ["exchange", "defi", "protocol", "access"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x3a8cccb969a61532d1e6005e2ce12c200caece87"
@@ -2753,6 +2784,7 @@
       "extensions": {
         "link": "https://dsla.network",
         "description": "Stacktical lets you use SLA Smart Contracts and Cryptocurrency Service Credits to balance the downtime risk that your customers are willing to bear with the uptime capabilities of your systems.",
+        "categories": ["defi", "protocol", "reward", "infrastructure", "smart-contract"],
         "ogImage": "https://storage.googleapis.com/stacktical-public/dsla-protocol_by_stacktical.png",
         "originChainId": 1,
         "originAddress": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe"
@@ -2768,6 +2800,7 @@
       "extensions": {
         "link": "https://www.boringdao.com/",
         "description": null,
+        "categories": ["defi", "protocol", "bridged", "infrastructure"],
         "ogImage": "https://boringdao-prod.oss-accelerate.aliyuncs.com/og-image-01.png",
         "originChainId": 1,
         "originAddress": "0x3c9d6c1c73b31c837832c72e04d3152f051fc1a9"
@@ -2783,6 +2816,7 @@
       "extensions": {
         "link": "https://team3d.io/",
         "description": null,
+        "categories": ["gaming", "defi", "reward", "pvp", "strategy"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x3d3d35bb9bec23b06ca00fe472b50e7a4c692c30"
@@ -2798,6 +2832,7 @@
       "extensions": {
         "link": "https://lto.network/",
         "description": "LTO Network is a blockchain platform for creating decentralized workflow applications, while maintaining data privacy and GDPR compliance. Developers and enterprises can use the LTO toolkit to either create new, or integrate existing solutions — and run them in a transparent, secure and decentralized way.",
+        "categories": ["infrastructure", "defi", "protocol", "privacy"],
         "ogImage": "https://www.ltonetwork.com/assets/meta/meta-home.png",
         "originChainId": 1,
         "originAddress": "0x3db6ba6ab6f95efed1a6e794cad492faaabf294d"
@@ -2813,6 +2848,7 @@
       "extensions": {
         "link": "https://linear.finance",
         "description": "A Cross-chain Decentralized Delta-One Asset Protocol with Unlimited Liquidity.",
+        "categories": ["defi", "protocol", "staking", "reward"],
         "ogImage": "/ogg.png",
         "originChainId": 1,
         "originAddress": "0x3e9bc21c9b189c09df3ef1b824798658d5011937"
@@ -2828,6 +2864,7 @@
       "extensions": {
         "link": "http://renproject.io/",
         "description": "Ren is an open protocol that enables the movement of value between blockchains. Ren's core product, RenVM, is focused on bringing interoperability to decentralized finance (DeFi). Ren was founded in 2017 and is headquartered in Singapore.",
+        "categories": ["infrastructure", "defi", "protocol", "bridged"],
         "ogImage": "/share.jpg",
         "originChainId": 1,
         "originAddress": "0x408e41876cccdc0f92210600ef50372656052a38"
@@ -2843,6 +2880,7 @@
       "extensions": {
         "link": "https://sora.org/",
         "description": "Sora believes that economies should be decentralized, yet rational. The Sora Decentralized Autonomous Economy (DAE) is the world's first decentralized economy, where everyone participates to create the best world together. Soramitsu (www.soramitsu.co.jp), founded by Makoto Takemiya, Ryu Okada, and Ikkei Matsuda, is one of the contributors to Sora (www.sora.org) with the aim to create a new type of economic system to improve the efficiency of society.",
+        "categories": ["defi", "governance", "protocol", "transactional"],
         "ogImage": "https://static.tildacdn.com/tild3064-6361-4864-b336-333635366531/1DXuvFuYkCGTfW58Yio_.png",
         "originChainId": 1,
         "originAddress": "0x40fd72257597aa14c7231a7b1aaa29fce868f677"
@@ -2858,6 +2896,7 @@
       "extensions": {
         "link": "https://dragonchain.com/",
         "description": "Dragonchain is one of the newly launched cryptocurrencies that is attracting crypto enthusiasts following its relaunch. The coin seems to be leading on the technology front irrespective of its market capitalisation trends, which is why it's also being anticipated to be <a href=\"https://www.coingecko.com/en/coins/ethereum\">Ethereum’s</a> competitor. Dragonchain is a hybrid blockchain platform, where sensitive business logic and smart contract functionality is held by the owner. Its cryptocurrency is denoted by the symbol DGRN & has a total supply of 433,494,437 coins. Dragonchain uses serverless smart contracts from its pre-built library. This feature is unique to this cryptocurrency, as it can create smart contracts, with or without cryptocurrencies.\r\n\r\nDragonchain was developed by Joe Roets who is its CEO and Chief Architect with a team of 4 core developers. The team is backed by a strong advisory board with Jeff Garzik on board who is established icon in the Bitcoin network. It wa...",
+        "categories": ["infrastructure", "chain", "defi", "protocol"],
         "ogImage": "https://images.dragonchain.com/banners/home.png",
         "originChainId": 1,
         "originAddress": "0x419c4db4b9e25d6db2ad9691ccb832c8d9fda05e"
@@ -2873,6 +2912,7 @@
       "extensions": {
         "link": "https://funfair.io/",
         "description": "FunFair is an <a href=\"https://www.coingecko.com/en/coins/ethereum\">Ethereum</a>-based platform for online casino gaming. Targeting the $47B online gambling market, FunFair isn’t actually a casino. Instead, the underlying gaming technology is licensed out to casinos and other gambling platforms. The FunFair team is attempting to solve some of the biggest problems online casinos face: slow performance, high operating costs, and lack of user trust. Through the use of blockchain technology and Fate Channels, an in-house built version of state channels, the products they license have the potential fix all of them.\r\n\r\nFUN is an ERC-20 token that you use in every part of the FunFair platform. It’s the only token accepted for in-game credits, how game creators in the marketplace are paid, what casinos must pay their licensing with and receive revenues in, and all fees on the platform must be paid in FUN. A total of 11,000,000,000 FUN tokens were created on June 22, 2017, and no more will b...",
+        "categories": ["gaming", "defi", "casino", "access"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b"
@@ -2888,6 +2928,7 @@
       "extensions": {
         "link": "https://noahcoin.org/",
         "description": "NOAHP is a unique coin that is connected to the ecosystem of the NOAH decentralized state, the only state that pays taxes to its citizens. NOAHP can provide with you a wide range of possibilities, such as participating in the development of the NOAH project, becoming a citizen of a wealthy state, using its anonymous abilities to make transactions, or even stake it in the DeFi liquidity pools.\r\n",
+        "categories": ["defi", "transactional", "access"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x41b3f18c6384dc9a39c33afeca60d9b8e61eaa9f"
@@ -2903,6 +2944,7 @@
       "extensions": {
         "link": "https://www.civic.com/",
         "description": "Using blockchain technology in an unprecedented way, Civic is more than just a coin or a cryptocurrency to trade. It’s an identity verification platform which is meant to make life easier, not only for the user but also for the entity who wishes to verify the identity. Rather than going through a long-winded document verification process, the Civic token enables the verification of identity directly in places where it is accepted. The Civic coin or Civic token (CVC) is the currency associated with Civic, which thrives on the <a href=\"https://www.coingecko.com/en/coins/ethereum\">Ethereum</a> blockchain, primarily exchanged during the identity verification process.\r\n\r\nAs a platform, the Civic cryptocurrency shows a lot of promise. While it is only available in the US presently (which may be disappointing news about its current potential), it’ll soon expand and come over to other countries - which should give it a nice bump in value. The blockchain is where the future lies, and the Civ...",
+        "categories": ["infrastructure", "access", "privacy"],
         "ogImage": "https://www.civic.com/wp-content/uploads/2020/11/OG-1200x630.jpg",
         "originChainId": 1,
         "originAddress": "0x41e5560054824ea6b0732e656e3ad64e20e94e45"
@@ -2918,6 +2960,7 @@
       "extensions": {
         "link": "https://pickle.finance/",
         "description": null,
+        "categories": ["defi", "protocol", "staking", "reward"],
         "ogImage": "https://i.imgur.com/N23Hjh0.png",
         "originChainId": 1,
         "originAddress": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5"
@@ -2933,6 +2976,7 @@
       "extensions": {
         "link": "https://spankchain.com/",
         "description": "A ​cryptoeconomic ​powered ​adult ​entertainment ​ecosystem built ​on ​the ​Ethereum ​network.",
+        "categories": ["defi", "access", "privacy"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x42d6622dece394b54999fbd73d108123806f6a18"
@@ -2948,6 +2992,7 @@
       "extensions": {
         "link": "https://dodoex.io/",
         "description": null,
+        "categories": ["defi", "exchange", "protocol", "reward"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x43dfc4159d86f3a37a5a4b3d4580b888ad7d4ddd"
@@ -2963,6 +3008,7 @@
       "extensions": {
         "link": "https://solve.care/",
         "description": "\"Solve.Care is a healthcare IT company that builds blockchain platforms which the team believes may improve the way healthcare is delivered and managed.\r\n\r\nThe Solve.Care platform reportedly uses blockchain technology as the underlying distributed ledger for coordinating care, benefits and payments between all parties in the chain of healthcare: patients, doctors, pharmacies, laboratories, employers, insurers, and others.\r\n\r\nSOLVE tokens may be used to secure efficient and transparent healthcare administration around the world. The token supply is fixed and the price variable, as determined by market supply and demand. SOLVE token runs natively on the Ethereum blockchain and is designed to follow the ERC20 token standard.\r\n\r\nSOLVE utility tokens are the currency used for transactions on the platform. According to the foundation, they can be utilized to pay for Care Administration Network fees, establish Care.Wallets, purchase Care.Cards, and participate in Care.Marketplace services ...",
+        "categories": ["infrastructure", "defi", "access", "rwa"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x446c9033e7516d820cc9a2ce2d0b7328b579406f"
@@ -2978,6 +3024,7 @@
       "extensions": {
         "link": "https://www.orchid.com/",
         "description": "The Orchid Protocol organizes bandwidth sellers into a structured peer-to-peer (P2P) network termed the Orchid Market. Customers connect to the Orchid Market and pay bandwidth sellers in order to form a proxy chain to a specific resource on the Internet.\r\n\r\nUnlike more common methods for sending and receiving data from the global Internet, proxy chains in the Orchid Market naturally separate information about the source of data from information about its destination; no single relay or proxy holds both pieces of information, or knows the identity of someone who does. The structure of the Orchid Market further supports this separation of information by providing strong resistance against collusion attacks – the ability of a group of bandwidth sellers to overcome this separation of knowledge.\r\n\r\nThe Internet was originally an open platform where people could freely learn and communicate. Unfortunately, as the Internet grew it became a place where people could be monitored, controlled,...",
+        "categories": ["privacy", "infrastructure", "access"],
         "ogImage": "https://www.orchid.com/assets/img/index/social.png",
         "originChainId": 1,
         "originAddress": "0x4575f41308ec1483f3d399aa9a2826d74da13deb"
@@ -2993,6 +3040,7 @@
       "extensions": {
         "link": "https://www.paxos.com/paxgold/",
         "description": "PAX Gold (PAXG) is an asset-backed token where one token represents one fine troy ounce of a London Good Delivery gold bar, stored in professional vault facilities. Anyone who owns PAXG has ownership rights to that gold under the custody of Paxos Trust Company. Since PAXG represents physical gold, its value is tied directly to the real-time market value of that physical gold.\r\n\r\nPAXG gives customers the benefits of actual physical ownership of specific gold bars with the speed and mobility of a digital asset. Customers are able to have fractional ownership of physical bars. On the Paxos platform, customers can convert their tokens to allocated gold, unallocated gold, or fiat currency (and vice versa) quickly and efficiently, reducing their exposure to settlement risk. PAXG is also available for trading on Paxos’ itBit exchange. PAXG will also be available on other crypto-asset exchanges, wallets, lending platforms and elsewhere within the crypto ecosystem. \r\n\r\nAt any time, PAXG hold...",
+        "categories": ["rwa", "value", "transactional"],
         "ogImage": "https://www.paxos.com/wp-content/uploads/2019/07/PAX-Gold_Logo-1.svg",
         "originChainId": 1,
         "originAddress": "0x45804880de22913dafe09f4980848ece6ecbaf78"
@@ -3008,6 +3056,7 @@
       "extensions": {
         "link": "https://renproject.io/",
         "description": "REN tokenized BCH\r\n\r\nOnce an asset is in the custody of RenVM, an ERC20 token at a 1:1 value is minted on Ethereum - this can then be used as any ERC20 can within the Ethereum ecosystem (for example, swaps, collateralization, trades etc.)",
+        "categories": ["bridged", "defi", "transactional", "wrapped"],
         "ogImage": "/share.jpg",
         "originChainId": 1,
         "originAddress": "0x459086f2376525bdceba5bdda135e4e9d3fef5bf"
@@ -3023,6 +3072,7 @@
       "extensions": {
         "link": "https://crypt-id.com",
         "description": "The official utility token of the Crypt-id project, the first cryptocurrency for the greater esoteric community.",
+        "categories": ["infrastructure", "access", "privacy"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x4599836c212cd988eaccc54c820ee9261cdaac71"
@@ -3038,6 +3088,7 @@
       "extensions": {
         "link": "http://www.telco.in",
         "description": "Telcoin is a new cryptocurrency based on the Ethereum blockchain that will be distributed by your national telecom operator and made available to everyone anywhere by tapping into synergies between the reach of mobile telecoms and the fast, borderless nature of blockchain technology. ",
+        "categories": ["transactional", "defi", "access"],
         "ogImage": "img/facebook.jpg",
         "originChainId": 1,
         "originAddress": "0x467bccd9d29f223bce8043b84e8c8b282827790f"
@@ -3053,6 +3104,7 @@
       "extensions": {
         "link": "https://www.coverprotocol.com/",
         "description": "\r\nCover Protocol is a peer-to-peer insurance market, where the way it operates is more similar to prediction market. Unlike other insurance protocols, the governance token is not used for underwriting risk. \r\n\r\nTo bootstrap coverage for a new protocol, market makers will need to be incentivized to stake collateral of DAI/yDAI to mint CLAIM and NOCLAIM tokens. All series covers a specified protocol and have a specified expiry date. During the expiry date, either CLAIM or NOCLAIM will have the full claim to the collaterals. \r\n\r\nFor example, if 100 DAI is used to provide coverage for Compound protocol until an expiry date, it will yield 100 CLAIM and 100 NOCLAIM tokens. On the expiry date, if there is a valid claim event, every CLAIM token will receive 1 DAI while NOCLAIM token will expire worthless. The converse is true if there is no valid claim event. In this case, every NOCLAIM token will receive 1 DAI while CLAIM token will expire worthless.",
+        "categories": ["defi", "protocol", "governance", "infrastructure"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713"
@@ -3068,6 +3120,7 @@
       "extensions": {
         "link": "https://yeld.finance/",
         "description": null,
+        "categories": ["defi", "protocol", "reward", "staking"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x468ab3b1f63a1c14b361bc367c3cc92277588da1"
@@ -3083,6 +3136,7 @@
       "extensions": {
         "link": "https://woo.network/",
         "description": null,
+        "categories": ["exchange", "defi", "protocol", "infrastructure"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b"
@@ -3098,6 +3152,7 @@
       "extensions": {
         "link": "https://damcrypto.com/",
         "description": "FLUX functions as the native currency of the Datamine Ecosystem and is powered by Datamine (DAM) token. Every 15 seconds you generate a bit of USDc in form of FLUX tokens.",
+        "categories": ["defi", "infrastructure", "protocol", "staking", "reward"],
         "ogImage": "https://datamine-crypto.github.io/realtime-decentralized-dashboard/logos/dam.png",
         "originChainId": 1,
         "originAddress": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9"
@@ -3113,6 +3168,7 @@
       "extensions": {
         "link": "https://www.the4thpillar.io/",
         "description": "Blockchain technology proposes the ideal foundation to simplify electronic data and documents exchange. To address this issue 4thpillar technologies short 4thtech proposed and later in 2018 developed a unique solution, which leverages trust provided by the blockchain and enables secure, immutable, electronic data and document exchange (FOURdx). Furthermore, document notarisation feature (FOURns) was introduced in 2020 enabling users to access the document time-stamp and verify its authenticity via file checksum, while 4thtech digital identity mechanism (FOURid) verifies and maps the connection between a blockchain wallet and a person, utilising the X.509 digital certificate standard.\r\n\r\n \r\n\r\nDeployed in 2018, the FOUR ERC-20 utility token delivers three specific solutions and enables; (1) token teleportation service (TTS); (2) token settlement service (MTO), and; (3) tokenization with GAS and DISCOUNT features used for FOURdx electronic data and documents exchange transactions.",
+        "categories": ["infrastructure", "privacy", "access"],
         "ogImage": "https://the4thpillar.io/wp-content/uploads/2020/02/4THTECH-LOGO-IDENTIFIER.png",
         "originChainId": 1,
         "originAddress": "0x4730fb1463a6f1f44aeb45f6c5c422427f37f4d0"
@@ -3128,6 +3184,7 @@
       "extensions": {
         "link": "https://projectserum.com/",
         "description": null,
+        "categories": ["exchange", "defi", "protocol", "infrastructure"],
         "ogImage": "https://i.imgur.com/58arUUs.png",
         "originChainId": 1,
         "originAddress": "0x476c5e26a75bd202a9683ffd34359c0cc15be0ff"
@@ -3143,6 +3200,7 @@
       "extensions": {
         "link": "http://city.pigice.com/",
         "description": "PIGX passed the \"blockchain + black pig\" traceability system, mainly through blockchain technology, detailed record of the whole cycle data chain of pig products, and the data protection and validity verification through encryption algorithm to solve the food safety last one. The problem of kilometers increases the brand value of the pigs.",
+        "categories": ["defi", "value", "reward"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x47e820df943170b0e31f9e18ecd5bdd67b77ff1f"
@@ -3158,6 +3216,7 @@
       "extensions": {
         "link": "https://cartesi.io/",
         "description": "What is Cartesi?\r\n\r\nCartesi is taking smart contracts on Ethereum to the next level. It is solving the urgent problem of scalability and high fees by implementing a variant of optimistic roll-ups. Most notably, Cartesi is revolutionizing smart contract programming by allowing developers to code with mainstream software stacks instead of Solidity. Noether is Cartesi's side-chain that’s optimized for ephemeral data, providing low-cost data availability to DApps.\r\n\r\nWhat makes Cartesi Unique?\r\n\r\nWhat gives Cartesi a competitive edge is that it allows developers to code their smart contracts and DApps directly with mainstream software components and Linux OS resources. This is a breakthrough for the productivity of existing DApp developers and for the adoption of non-blockchain developers. This is a necessary step to the very future of blockchains and their applications. In addition, key highlights include:\r\n\r\nTransaction scaling: 20-fold+ TPS increase over Ethereum\r\n\r\nComputational sca...",
+        "categories": ["smart-contract", "infrastructure", "protocol"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x491604c0fdf08347dd1fa4ee062a822a5dd06b5d"
@@ -3173,6 +3232,7 @@
       "extensions": {
         "link": "https://www.foam.space/",
         "description": "FOAM is an open protocol for proof of location on Ethereum. Our mission is to build a consensus driven map of the world, empowering a fully decentralized web3 economy with verifiable location data. FOAM incentivizes the infrastructure needed for privacy-preserving and fraud-proof location verification. The starting point for FOAM is static proof of location, where a community of Cartographers curate geographic Points of Interest on the FOAM map. Through global community-driven efforts, FOAM’s dynamic proof of location protocol will enable a permissionless and privacy-preserving network of radio beacons that is independent from external centralized sources and capable of providing secure location verification services.\r\n\r\nFOAM Token Functionality\r\n1. Add and Curate Geographic Points of Interest\r\nThe FOAM Spatial Index Visualizer allows Cartographers to participate in interactive TCR POIs on a map. Users can add points to the map, validate new candidates and verify the map by visiting...",
+        "categories": ["infrastructure", "defi", "protocol", "access", "privacy"],
         "ogImage": "https://foam.space/OG.png",
         "originChainId": 1,
         "originAddress": "0x4946fcea7c692606e8908002e55a582af44ac121"
@@ -3188,6 +3248,7 @@
       "extensions": {
         "link": "https://www.quant.network",
         "description": "London-based Quant Network is set to revolutionise blockchain technology with the development of their blockchain operating system Overledger. The experienced team are determined to fulfil the original vision of the internet by creating an open trusted network for people, machines, and data to operate securely and safely.\r\n\r\nOverledger -the first interoperable blockchain operating system that facilitates internet-scale development of decentralised, multi-chain applications. Overledger has the ability to unlock and distribute value and applications across current and future blockchains. It is an agnostic platform that connects the world's networks to blockchains and ensures you're not limited to any single a vendor or technology. Overledger is the only platform that facilitates the development of internet-scales development of decentralised, multi-chain applications.",
+        "categories": ["infrastructure", "chain", "defi", "access"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x4a220e6096b25eadb88358cb44068a3248254675"
@@ -3203,6 +3264,7 @@
       "extensions": {
         "link": "https://morpheuslabs.io/",
         "description": "Morpheus Lab Platform Gives your the flexibility to experiment, using the broad range of functionalities on our platform, to build and develop blockchain applications that suit the needs of your business. Simplifies and expedites blockchain application development, gives you the flexibility to choose between available programming languages and blockchain runtimes that better suit your needs. You receive unparalleled benefits from an integrated collaborative development environment, workspace management, version control repository and many preconfigured tasks. Let our platform do the heavy lifting while you focus on value-adding work such as application creation and experimenting with the blockchain technologies at a fraction of the cost and time.",
+        "categories": ["infrastructure", "smart-contract", "access"],
         "ogImage": "/static/blue-ml-final-89ae445cf047a8082ddeb59384e8ace0.jpg",
         "originChainId": 1,
         "originAddress": "0x4a527d8fc13c5203ab24ba0944f4cb14658d1db6"
@@ -3218,6 +3280,7 @@
       "extensions": {
         "link": "https://www.wrapped.com",
         "description": "Wrapped Zcash is a 1:1 equivalent of Zcash represented as an ERC-20 on Ethereum.",
+        "categories": ["wrapped", "privacy", "defi", "transactional"],
         "ogImage": "images/img_og.jpg",
         "originChainId": 1,
         "originAddress": "0x4a64515e5e1d1073e83f30cb97bed20400b66e10"
@@ -3233,6 +3296,7 @@
       "extensions": {
         "link": "https://orai.io/",
         "description": "Oracle Artificial Intelligence for Blockchains",
+        "categories": ["ai", "infrastructure", "defi", "protocol"],
         "ogImage": "https://gateway.datochain.com/ipfs/QmdFNkMfe3ZNK5oLxPFBn2CkpSwEqQrNVCkGXp12ivG5D7",
         "originChainId": 1,
         "originAddress": "0x4c11249814f11b9346808179cf06e71ac328c1b5"

--- a/index/polygon/erc20.json
+++ b/index/polygon/erc20.json
@@ -5499,7 +5499,7 @@
       "address": "0xa804304f8e7c9ab5932ac3a4cc1468e40183d199",
       "name": "Old Test Dai (dev)",
       "extensions": {
-        "blacklist": true
+        "blacklist": true,
         "categories": ["usd-stablecoin", "transactional", "defi", "maker"]
       }
     },

--- a/index/polygon/erc20.json
+++ b/index/polygon/erc20.json
@@ -1280,7 +1280,7 @@
       "extensions": {
         "link": "https://unifund.global/",
         "description": "Unifund is a layer 2 system on Uniswap enabling the creation of trustless managed trading groups wish customizable risk profiles",
-        "categories": ["defi", "protocol", "exchange"]
+        "categories": ["defi", "protocol", "exchange"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x04b5e13000c6e9a3255dc057091f3e3eeee7b0f0"

--- a/index/polygon/erc721.json
+++ b/index/polygon/erc721.json
@@ -732,7 +732,7 @@
       "extensions": {
         "link": "https://www.boomland.io/",
         "description": "BoomLand is Blockchain game developer and publisher with its own NFT marketplace and decentralized ecosystem. Our mission is to push the mass adoption of Web3 gaming by targeting and onboarding traditional Web2 players. Our first game, “Hunters On-Chain”, is a mobile first, multiplayer RPG.",
-        "categories": ["gaming", "rpg", "reward", "fantasy", "p2e"],
+        "categories": ["gaming", "rpg", "reward", "fantasy", "p2e"]
       }
     },
     {

--- a/index/polygon/erc721.json
+++ b/index/polygon/erc721.json
@@ -16,6 +16,7 @@
       "extensions": {
         "link": "https://darkearth.gg/",
         "description": "Dark Earth is a futuristic science fiction metaverse that makes use of decentralized elements such as NFTs (Non-Fungible Tokens).",
+        "categories": ["gaming", "art", "defi", "reward", "fantasy", "strategy", "p2e"],
         "ogImage": "https://raw.githubusercontent.com/0xsequence/token-directory/d9b09a44e1efa2a962f9d18247da3292773c8766/images/dark-earth-banner.png",
         "originChainId": 137,
         "originAddress": null
@@ -31,6 +32,7 @@
       "extensions": {
         "link": "https://darkearth.gg/",
         "description": "Dark Earth is a futuristic science fiction metaverse that makes use of decentralized elements such as NFTs (Non-Fungible Tokens).",
+        "categories": ["gaming", "art", "reward", "fantasy", "strategy"],
         "ogImage": "https://raw.githubusercontent.com/0xsequence/token-directory/master/images/dark-earth-mystery-capsule-banner.png",
         "originChainId": 137,
         "originAddress": null
@@ -46,6 +48,7 @@
       "extensions": {
         "link": "https://neondistrict.io/",
         "description": "Neon District is a free-to-play cyberpunk role-playing game. Collect characters and gear, craft and level up teams, and battle against other players through competitive multiplayer and in turn-based combat.",
+        "categories": ["gaming", "defi", "reward", "cyberpunk", "strategy", "p2e"],
         "ogImage": "https://lh3.googleusercontent.com/_EmX1Ndvx24VZ8-pmDC7NjgICFnUC-YIuxDYKCO2-T4WYbMyPnnH0oAYKXcu03_vMHQNGX-S0jcte66UEnThkkGIo6EA3wwpiQox=h600",
         "originChainId": 1,
         "originAddress": null
@@ -61,6 +64,7 @@
       "extensions": {
         "link": "https://blocklords.io",
         "description": "BLOCKLORDS is a smart-contract based grand strategy game where players are thrown into a medieval world and will have to fight their way to the top. HERO NFTs include a hero’s name, base stats, equipped item, traits, and title, making them valuable assets and necessary in order to play BLOCKLORDS ETH at launch.",
+        "categories": ["gaming", "defi", "reward", "strategy", "pvp", "simulation", "p2e"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x2c04e6dd23c33a66f58dfb79dfb15285336c92d0"
@@ -76,6 +80,7 @@
       "extensions": {
         "link": "https://www.infinitystar.io",
         "description": "Infinity Star is an auto-battle RPG, set in a not-so distant dystopian future about characters who escaped an evil research lab\r\nto gain their freedom back. Grind your gears and gather companions to escape the lab for freedom! \r\n中国大陆的各位玩家，请访问 https://infinitystar.cc/ 谢谢大家！",
+        "categories": ["art", "reward", "access"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x543ecfb0d28fa40d639494957e7cba52460f490e"
@@ -91,6 +96,7 @@
       "extensions": {
         "link": "https://godsunchained.com/?refcode=0x5b3256965e7C3cF26E11FCAf296DfC8807C01073",
         "description": "Alert: This is the legacy collection.  Gods Unchained is a free-to-play, turn-based competitive trading card game in which cards can be bought and sold on the OpenSea marketplace. Players use their collection to build decks of cards, and select a God to play with at the start of each match. The goal of the game is to reduce your opponent's life to zero. Each deck contains exactly 30 cards. On OpenSea, cards can be sold for a fixed price, auctioned, or sold in bundles.",
+        "categories": ["gaming", "tcg", "reward", "fantasy", "pvp", "strategy", "p2e"],
         "ogImage": "https://godsunchained.com/assets/images/backgrounds/wide-hi-res-god.jpg",
         "originChainId": 1,
         "originAddress": "0x6ebeaf8e8e946f0716e6533a6f2cefc83f60e8ab"
@@ -106,6 +112,7 @@
       "extensions": {
         "link": "https://emblem.pro",
         "description": "An entire wallet inside an NFT. Emblem Vaults are containers of assets. Transfer / Gift / Sell entire collections of tokens and assets by transferring the NFT.",
+        "categories": ["art", "access", "reward"],
         "ogImage": "https://uploads-ssl.webflow.com/5eb3d91888ad6f4b2ba7e995/5eb41b530505e2d9f0282474_img%203-min.jpg",
         "originChainId": 1,
         "originAddress": "0x82c7a8f707110f5fbb16184a5933e9f78a34c6ab"
@@ -121,6 +128,7 @@
       "extensions": {
         "link": "http://www.spellsofgenesis.com",
         "description": "The 1st blockchain-based mobile game ever made, Spells of Genesis combines TCG functionalities with the point-and-shoot aspects of arcade games. Players have to collect and combine cards to create the strongest deck in order to fight their enemies.",
+        "categories": ["gaming", "reward", "tcg", "fantasy", "strategy", "pvp"],
         "ogImage": "https://spellsofgenesis.com/wp-content/uploads/2020/04/soglogo.jpg",
         "originChainId": 1,
         "originAddress": "0x9227a3d959654c8004fa77dffc380ec40880fff6"
@@ -136,6 +144,7 @@
       "extensions": {
         "link": "https://www.drakons.io/",
         "description": "Drakons are genetically unique and artistically designed digital dragons created as crypto collectibles. Collect according to their attributes in terms of Agility, Strength, Intelligence and Health Points. Collect now so you can breed, sire, sell, battle and be a Drakon Master!",
+        "categories": ["gaming", "art", "defi", "reward", "fantasy", "pvp", "p2e"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x989e1fb123b67afd66e10574c8b409bc6e812d9a"
@@ -151,6 +160,7 @@
       "extensions": {
         "link": "https://www.cometh.io",
         "description": "Cometh is a DeFi powered game with yield generating NFT.\r\nGet spaceships, explore the galaxy and earn tokens.",
+        "categories": ["gaming", "defi", "reward", "sci-fi", "strategy", "pvp", "p2e"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0xbcd4f1ecff4318e7a0c791c7728f3830db506c71"
@@ -166,6 +176,7 @@
       "extensions": {
         "link": "https://www.cryptokitties.co/",
         "description": "CryptoKitties is a game centered around breedable, collectible, and oh-so-adorable creatures we call CryptoKitties! Each cat is one-of-a-kind and 100% owned by you; it cannot be replicated, taken away, or destroyed.",
+        "categories": ["gaming", "art", "reward", "access"],
         "ogImage": "https://www.cryptokitties.co/images/share.png",
         "originChainId": 1,
         "originAddress": "0x06012c8cf97bead5deae237070f9587f8e7a266d"
@@ -181,6 +192,7 @@
       "extensions": {
         "link": "https://marketplace.digitalax.xyz/",
         "description": "The DIGITALAX ERC-721 NFTs are the master garments and accessories on the DIGITALAX marketplace and are each designed exclusively by our 30+ Global Designer Network — a group of uber talented 3D digital fashion designers from Europe, US, Asia, Afria, Australia! \r\n\r\nDIGITALAX is the first dedicated Digital-Only Fashion Auction Exchange Platform and Open Source Digital Fashion Toolkit. We are bringing new industry standards around digital goods, Open Digital licenses, digital fashion pricing transparency, digital supply chain automation and addressing core problems around NFT liquidity and stability. We are positioning as THE first digital fashion NFT engine built on the Ethereum network for all gaming, VR and metaverses.\r\n\r\nCheck out more of our exclusive and amazing digital fashion designs at www.digitalax.xyz",
+        "categories": ["art", "gaming", "defi", "reward", "access"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x0b509f4b044f713a91bb50535914f7ad160532fe"
@@ -196,6 +208,7 @@
       "extensions": {
         "link": "https://www.sandbox.game/",
         "description": "The Sandbox is a community-driven platform where creators can monetize voxel assets and gaming experiences on the blockchain. The Sandbox metaverse comprises a map made up of 166,464 LANDS.  LAND owners can host contests and events, stake SAND to earn and customize assets, monetize assets and experiences, vote in the metaverse governance, play games that you or others create, and more! Trade the collection and keep your eyes peeled for future drops.",
+        "categories": ["gaming", "defi", "reward", "open-world", "p2e"],
         "ogImage": "/The-Sandbox.png",
         "originChainId": 1,
         "originAddress": "0x50f5474724e0ee42d9a4e711ccfb275809fd6d4a"
@@ -211,6 +224,7 @@
       "extensions": {
         "link": "https://sorare.com",
         "description": "Sorare is a fantasy football game where managers can trade official digital collectibles. The platform is growing fast, with a global audience collecting, buying, and selling their favorite players in the form of blockchain-backed NFTs. The Sorare team has secured the rights to European giants like Atletico Madrid, Juventus, and Bayern Munich, as well as the MLS, Korean League, and Japanese League.",
+        "categories": ["gaming", "sports", "defi", "reward", "pvp"],
         "ogImage": null,
         "originChainId": 1,
         "originAddress": "0x629a673a8242c2ac4b7b8c5d8735fbeac21a6205"
@@ -226,6 +240,7 @@
       "extensions": {
         "link": "https://www.daznboxing.io/",
         "description": "Make Fight Night Last Forever. The DAZN Boxing Matchroom Collection 1 includes the release of 30,000 boxing moments. Build your own digital collection of the biggest moments in boxing either by purchasing a pack from DAZNBoxing.io or via the marketplace.",
+        "categories": ["sports", "art", "reward", "access"],
         "ogImage": "https://quandefi-public-bucket.s3.us-east-1.amazonaws.com/DAZN/DAZN%20Banner.png",
         "originChainId": 1,
         "originAddress": null
@@ -241,6 +256,7 @@
       "extensions": {
         "link": "https://www.daznboxing.io/",
         "description": "Become a part of Boxing history with the Canelo Alvarez Premier PFP (Profile Picture) Collection! Grab your PFP now from DAZNBoxing.io and experience fight night like you never have before! This premier PFP is your ticket to watch the full fight card in the DAZN DECENTRALAND METAVERSE STADIUM. Each PFP purchase also comes with 2 free months of a DAZN streaming subscription and holders will automatically be entered to win either a Mutant Ape NFT or a VIP Trip to Canelo's next fight. Winners will be announced in Decentraland at the end of fight night!",
+        "categories": ["sports", "art", "reward", "access"],
         "ogImage": "https://assets.sequence.info/-0Zajvtt/IMG_8588.jpg",
         "originChainId": 1,
         "originAddress": null
@@ -256,6 +272,7 @@
       "extensions": {
         "link": "https://www.themoopians.io/",
         "description": "Welcome to a place where colour and creativity reigns. The Moopians are customisable chibi characters on the blockchain that bring with them a plethora of IRL benefits. Find out what exciting journey your Moopian will bring you on today at: www.themoopians.io. A (super) fun initiative by Siam Square Mookata.",
+        "categories": ["gaming", "art", "reward", "fantasy", "p2e"],
         "ogImage": "https://i.postimg.cc/XqBtn8JZ/Moopians.png"
       }
     },
@@ -269,6 +286,7 @@
       "extensions": {
         "link": "https://sunflower-land.com/",
         "description": "Bumpkins are beautiful, bold and ready for an adventure. Use your Bumpkin to explore the Sunflower MetaVerse and grow your farming empire.",
+        "categories": ["gaming", "reward", "access", "fantasy", "strategy", "p2e"],
         "ogImage": "https://i.seadn.io/gcs/files/e4994945529c28946af305dd983c8e65.png?auto=format&w=3840",
         "featured": true
       }
@@ -285,6 +303,7 @@
       "extensions": {
         "link": "https://galxe.com",
         "description": "Galxe OAT (On-chain Achievement Token) is a digital badge standard on Polygon and BNB Chain to record your on-chain and off-chain life experiences. Co-launched by Galxe, Polygon Studios, and NFT Storage by Filecoin and IPFS.",
+        "categories": ["art", "reward", "access"],
         "ogImage": "",
         "featured": true
       }
@@ -299,6 +318,7 @@
       "extensions": {
         "link": "https://www.planetmojo.io/",
         "description": "Mojos are devilishly powerful plant creatures in need of your help. There are 4444 uniquely generated 3D game-playable characters that will work across the expanding games and metaverse of Planet Mojo",
+        "categories": ["gaming", "art", "reward", "fantasy", "p2e"],
         "ogImage": "https://imagedelivery.net/1AztEX5-1VUaJuxpzoqU7A/8d72828f-39dd-4d0d-780e-cbf7ec70e700/public"
       }
     },
@@ -312,6 +332,7 @@
       "extensions": {
         "link": "https://www.planetmojo.io/",
         "description": "Planet Mojo is an ecosystem of interconnected games built by Mystic Moose and set inside a mysterious alien planet with an evolving narrative. Players compete with customized teams of fantastical creatures in a suite of eSports, PvP games.",
+        "categories": ["gaming", "art", "reward", "fantasy", "p2e"],
         "ogImage": "https://i.seadn.io/gcs/files/1eda452d25e276592665fc10cfd3ae64.png?auto=format&dpr=1&w=3840"
       }
     },
@@ -325,6 +346,7 @@
       "extensions": {
         "link": "https://www.planetmojo.io/",
         "description": "Planet Mojo is an ecosystem of interconnected games built by Mystic Moose and set inside a mysterious alien planet with an evolving narrative. Players compete with customized teams of fantastical creatures in a suite of eSports, PvP games.",
+        "categories": ["gaming", "art", "reward", "fantasy", "p2e"],
         "ogImage": "https://imagedelivery.net/1AztEX5-1VUaJuxpzoqU7A/8bf9f48f-5da8-4c92-bb30-ca3db9a5ee00/public"
       }
     },
@@ -338,6 +360,7 @@
       "extensions": {
         "link": "https://www.planetmojo.io/",
         "description": "The limited edition Golden Mojo represents participation in the inaugural Mojo Melee 2023 Mojo Bowl Tournament.",
+        "categories": ["gaming", "art", "reward", "fantasy", "p2e"],
         "ogImage": "https://imagedelivery.net/1AztEX5-1VUaJuxpzoqU7A/9deefcba-6c4e-4c45-d926-ee25f9117700/public"
       }
     },
@@ -351,6 +374,7 @@
       "extensions": {
         "link": "https://www.planetmojo.io/",
         "description": "Mod-able Mojos are a new collection from Planet Mojo where users will be able to swap parts and customize the look of their Mojos both in-game, and on-chain. Mojos are powerful plant heroes brought forth by the planet to battle the deadly threat known as the Scourge. They are 3D playable game characters in Mojo Melee and future games and experiences set inside the Planet Mojo Universe.",
+        "categories": ["gaming", "art", "reward", "fantasy", "p2e"],
         "ogImage": "https://imagedelivery.net/1AztEX5-1VUaJuxpzoqU7A/bf6e7d2d-2187-46e1-c728-ac097b1a6a00/public"
       }
     },{
@@ -363,6 +387,7 @@
       "extensions": {
         "link": "https://www.planetmojo.io/",
         "description": "A limited edition Cinematic Collector's Pass \"movie poster\" NFT created for the community in celebration of the release of Planet Mojo's first cinematic trailer!",
+        "categories": ["art", "reward", "access"],
         "ogImage": "https://imagedelivery.net/1AztEX5-1VUaJuxpzoqU7A/bf6e7d2d-2187-46e1-c728-ac097b1a6a00/public"
       }
     },
@@ -376,6 +401,7 @@
       "extensions": {
         "link": "https://www.planetmojo.io/",
         "description": "The Planet Mojo VIP Playtest Pass NFT is a ticket that provides access to Pre-Alpha testing of the auto battler game Mojo Melee. Pass holders will be eligible to earn in-game rewards, a special badge and invitations to special events.",
+        "categories": ["gaming", "access", "reward"],
         "ogImage": "https://imagedelivery.net/1AztEX5-1VUaJuxpzoqU7A/bf6e7d2d-2187-46e1-c728-ac097b1a6a00/public"
       }
     },
@@ -389,6 +415,7 @@
       "extensions": {
         "link": "https://metastar.gg/",
         "description": "The playable characters in MetaStar Strikers! With unique visual looks and four in-game stats, you won’t want to miss these!",
+        "categories": ["gaming", "sports", "defi", "reward", "pvp", "p2e"],
         "ogImage": "https://i.seadn.io/gcs/files/c01f03d12b96549667526df5ebb3903d.png?auto=format&dpr=1&w=3840"
       }
     },
@@ -402,6 +429,7 @@
       "extensions": {
         "link": "https://metastar.gg/",
         "description": "Welcome to the home of MetaStar Strikers: Avatars on OpenSea. Discover the best items in this collection.",
+        "categories": ["gaming", "sports", "defi", "reward", "pvp", "p2e"],
         "ogImage": "https://i.seadn.io/gcs/files/506167396d6d2f96492606fc82c8f58a.png?auto=format&dpr=1&w=3840"
       }
     },
@@ -415,6 +443,7 @@
       "extensions": {
         "link": "https://champions.io/",
         "description": "Primes sit at the highest tier of ascension. They are the strongest in 1v1 & receive daily gold claims. \n\nMeet the glorious 7622 champions who have ascended to the status of Prime Eternal. These Divine few have no equal in the arena, and receive the highest level of in game benefits. Prime Eternals will never be minted again, and give you access to the growing fantasy world Massina. Claim your Prime Eternal Champion, to play in Champions: Ascension a AAA play-to-earn game by Rough House Games.",
+        "categories": ["gaming", "art", "reward", "fantasy", "pvp", "p2e"],
         "ogImage": "https://i.seadn.io/s/primary-drops/0xe22575fad77781d730c6ed5d24dd1908d6d5b730/27298272:about:media:9c7c15d2-b0d6-4383-8b82-ad798b2161d0.png?auto=format&dpr=1&w=2048"
       }
     },
@@ -428,6 +457,7 @@
       "extensions": {
         "link": "https://champions.io/",
         "description": "Pets are a collection of unique companions who inhabit the universe of Champions Ascension. \n\nPets of Massina is a collection of unique companions that inhabit the universe of Champions Ascension. These creatures love joining forces with Champions, aiding them in their adventures, boosting their combat prowess, unlocking secrets and breaking hearts.",
+        "categories": ["gaming", "art", "reward", "fantasy", "p2e"],
         "ogImage": "https://i.seadn.io/s/primary-drops/0x58481864048671c833a0cee0d467d34534171713/27298275:about:media:616a3939-2303-4ca6-8a22-fbd687a7cf72.png?auto=format&dpr=1&w=2048"
       }
     },
@@ -441,6 +471,7 @@
       "extensions": {
         "link": "https://champions.io/",
         "description": "The Imperial Gallery are items that will be used to enhance all player-generated content in Massina. \n\nThe Imperial Gallery hosts the most prized works of art, items and artifacts that have been collected over centuries by the line of Massina Emperors. People travel from all corners of the world to witness the marvels contained in the gallery. Would-be thieves are executed on site. Children and Beadols pay half.",
+        "categories": ["art", "reward", "access"],
         "ogImage": "https://i.seadn.io/s/primary-drops/0x13d15d8b7b2bf48cbaf144c5c50e67b6b635b5cd/27298278:about:media:90f2f170-5792-47ce-ae57-d77e049677d8.png?auto=format&dpr=1&w=2048"
       }
     },
@@ -454,6 +485,7 @@
       "extensions": {
         "link": "https://champions.io/",
         "description": "Elementals were forged for AOE & Group combat. They represent the houses of Air, Fire, Earth & Water. \n\nAs the House of the World was shattered, the Elemental Houses would rise from its remains. Mighty Champions willing to represent the four Elements: Air, Fire, Earth and Water, claimed their right to fight in the Colosseum Eternal, but the Emperor had other plans. Until now. The Elemental Champions are allowed in the arena once more and the stakes have never been higher.",
+        "categories": ["gaming", "art", "reward", "fantasy", "pvp", "p2e"],
         "ogImage": "https://i.seadn.io/s/primary-drops/0xc615bfb753fc2bab65065987391d046105673284/27298225:about:media:01dc39bc-a9cf-4ec9-b802-9e1f6a7784e1.png?auto=format&dpr=1&w=2048"
       }
     },
@@ -467,6 +499,7 @@
       "extensions": {
         "link": "https://champions.io/",
         "description": "Crystals, created from Raw Essence, play a major role in the progression & imbuement of Champions. \n\nThe Crystal creation process had been a well kept secret of Massina's Alchemists for ages. The power contained within the Essence Crystals has many uses, and they are highly sought after by aspiring Maestros that wish to imbue their Grunts with the power of the Seven Houses. Under the watch of Head Alchemist Prometheus, Crystal forging has become a profitable business for everyone with enough coin to pay for their services.",
+        "categories": ["gaming", "art", "reward", "fantasy", "p2e"],
         "ogImage": "https://i.seadn.io/s/primary-drops/0x80e919391b82815327842ae55f57430571fc8b2c/31436194:about:media:e33bb8b6-eaf9-4e2f-8d85-ae724e796eb9.png?auto=format&dpr=1&w=2048"
       }
     },
@@ -480,6 +513,7 @@
       "extensions": {
         "link": "https://champions.io/",
         "description": "Scrolls are a rare progression component required to achieve all levels of ascension. \n\nThe path of Ascension is at the core of the games in Massina. Maestros can only dream of one day leading an Eternal into battle, but very few accomplish such a feat. The priests of the Tower of Ascension have very strict requirements in order to deem a Champion worthy of their rituals, and the proper Scrolls of Ascension are proof that both Maestro and Champion understand the great power that will be bestowed upon them.",
+        "categories": ["gaming", "art", "reward", "fantasy", "p2e"],
         "ogImage": "https://i.seadn.io/s/primary-drops/0xc7dc85e36d067bb5c8e9f3a1a1086c99a1a3cdb2/31436204:about:media:469f6da7-ec39-4074-9a85-9fc514b2e9b7.png?auto=format&dpr=1&w=2048"
       }
     },
@@ -493,6 +527,7 @@
       "extensions": {
         "link": "https://champions.io/",
         "description": "Gruesome parts, combined to create a powerful monster, set to defend all user generated content. \n\nMassina has no shortage of terrifying and fantastical creatures. At the crossroads of many worlds, there is a new abomination entering the Arena every day. Some Maestros have taken to collecting these monsters in grotesque menageries in hopes of using them to train their Champions, or perhaps eliminate a powerful rival.",
+        "categories": ["gaming", "art", "reward", "fantasy", "p2e"],
         "ogImage": "https://i.seadn.io/s/primary-drops/0x3be1e1eb87d50064507c453e1e266d2b07ccc3b2/31436336:about:media:59ce19e1-304d-4884-9979-8797d4751aaa.png?auto=format&dpr=1&w=2048"
       }
     },
@@ -506,6 +541,7 @@
       "extensions": {
         "link": "https://sunflower-land.com/",
         "description": "Introducing Buds, the friendly farming pets that will turbo charge your Sunflower Land farm and gaming experience. These buds mark the start of a new era of collectibles and utility in Sunflower Land, providing exciting gameplay avenues. Players will now be able to collect a one of a kind Sunflower Land collectible and use it in their farming adventure.",
+        "categories": ["gaming", "art", "reward", "fantasy", "p2e"],
         "ogImage": "https://i.seadn.io/gcs/files/6531ea1f4be7477f5bbf92ac2ebc51b4.gif?auto=format&dpr=1&w=3840"
       }
     },
@@ -519,6 +555,7 @@
       "extensions": {
         "link": "https://www.revvracing.com/",
         "description": "REVV Racing is a competitive racing game, and part of the REVV Motorsport ecosystem.Designed from the ground-up to be interoperable, and utilising the REVV and SHRD tokens, REVV Racing provides both collectable and gameplay experiences for racing game players and driving enthusiast - whether competitive or casual, collectors, or fans of motorsports in general.Ready to race? We'll see you on the track!",
+        "categories": ["gaming", "sports", "driving", "p2e"],
         "ogImage": "https://i.seadn.io/gcs/files/6079f927aa6fb503bfada25572ede681.png?auto=format&dpr=1&w=3840"
       }
     },
@@ -531,6 +568,7 @@
       "extensions": {
         "link": "https://www.cryptounicorns.fun/",
         "description": "Crypto Unicorns is a Digital Pet Collecting and Farming Game built on the blockchain.In Crypto Unicorns, gameplay centers around awesomely unique Unicorn NFTs which players combine with Land NFTs to utilize in a fun farming simulation, as well as other gameplay including Jousting, Racing, and Team RPG.",
+        "categories": ["gaming", "reward", "access", "fantasy", "p2e"],
         "ogImage": "https://i.seadn.io/gcs/files/7de573fd08112f68f44c17ec91d49b54.png?auto=format&dpr=1&h=500"
       }
     },
@@ -543,6 +581,7 @@
       "extensions": {
         "link": "https://www.cryptounicorns.fun/",
         "description": "Shadowcorns are the dark, brooding cousins of the frolicking, carefree heroes of the Crypto Unicorns universe! The 3,000 Shadowcorns hatched from Common, Rare, and Mythic Shadowcorn Eggs form the foundation of the long-term PvE gameplay in Crypto Unicorns, being the key to the domination and production of Shadowcorn Minions!",
+        "categories": ["gaming", "reward", "fantasy", "p2e"],
         "ogImage": "https://i.seadn.io/gcs/files/7de573fd08112f68f44c17ec91d49b54.png?auto=format&dpr=1&h=500"
       }
     },
@@ -555,6 +594,7 @@
       "extensions": {
         "link": "https://www.cryptounicorns.fun/",
         "description": "Minions form the power base of Shadowcorns, the ill-tempered arch-enemies of Crypto Unicorns, the blockchain game where you can collect, hatch, and breed your own NFT Unicorns and Battle! Shadowcorns have each mastered their own dark arts and unique tricks to craft a vast array of different henchmen to send forth in their quest for total domination. In order to preserve this ancient knowledge, it is transcribed into the pages of Rituals, each one providing the details of what's required to summon a specific Minion type.",
+        "categories": ["gaming", "reward", "fantasy", "p2e"],
         "ogImage": "https://i.seadn.io/gcs/files/7de573fd08112f68f44c17ec91d49b54.png?auto=format&dpr=1&h=500"
       }
     },
@@ -567,6 +607,7 @@
       "extensions": {
         "link": "https://www.cryptounicorns.fun/",
         "description": "Crypto Unicorns is a Digital Pet Collecting and Farming Game built on the blockchain.In Crypto Unicorns, gameplay centers around awesomely unique Unicorn NFTs which players combine with Land NFTs to utilize in a fun farming simulation, as well as other gameplay including Jousting, Racing, and Team RPG.",
+        "categories": ["gaming", "reward", "access", "fantasy", "p2e"],
         "ogImage": "https://i.seadn.io/gcs/files/7de573fd08112f68f44c17ec91d49b54.png?auto=format&dpr=1&h=500"
       }
     },
@@ -579,6 +620,7 @@
       "extensions": {
         "link": "https://symbiogenesis.app/",
         "description": "Square Enix Global NFT Collectible Art Project - SYMBIOGENESIS - 10,000 character (Ethereum) - collectible artworks meet real game utility.\r\n \r\nGame Utility\r\nThis game's genre is defined as \"Narrative-unlocked NFT entertainment\"\r\nAs you unlock the main story, as well as the individual stories of each character, unravel the mysteries of the world.\r\n\r\nThe member cards are able to be used as utility within the game.",
+        "categories": ["gaming", "art", "reward", "access"],
         "ogImage": "https://i.seadn.io/gcs/files/e43c4fc02b76343e64dd95d9737121bc.png?w=500&auto=format"
       }
     },
@@ -591,6 +633,7 @@
       "extensions": {
         "link": "https://www.planetmojo.io/",
         "description": "Mod-able Mojos are a new collection from Planet Mojo where users will be able to swap parts and customize the look of their Mojos both in-game, and on-chain. Mojos are powerful plant heroes brought forth by the planet to battle the deadly threat known as the Scourge. They are 3D playable game characters in Mojo Melee and future games and experiences set inside the Planet Mojo Universe.",
+        "categories": ["gaming", "art", "reward", "fantasy", "p2e"],
         "ogImage": "https://imagedelivery.net/1AztEX5-1VUaJuxpzoqU7A/bf6e7d2d-2187-46e1-c728-ac097b1a6a00/public"
       }
     },
@@ -603,6 +646,7 @@
       "extensions": {
         "link": "https://pooky.gg/",
         "description": "Stickers are customisations for your Pookyballs (https://opensea.io/collection/pookyballs). They're used in Pooky to supercharge your predictions and build custom strategies!",
+        "categories": ["art", "reward", "access"],
         "ogImage": "https://i.seadn.io/gcs/files/a1b94edb173f4880773aa1282b4a06d4.png?w=500&auto=format"
       }
     },
@@ -613,7 +657,8 @@
       "symbol": "shatterpoint",
       "type": "erc721",
       "extensions": {
-        "description": "Shatterpoint is a play-to-earn free-to-play blockchain action role-playing game built on the Polygon network where players can own NFT heroes and earn QUA and SHA tokens. The game features a PvP arena where players can battle each other and a PvE campaign mode that players can progress through."
+        "description": "Shatterpoint is a play-to-earn free-to-play blockchain action role-playing game built on the Polygon network where players can own NFT heroes and earn QUA and SHA tokens. The game features a PvP arena where players can battle each other and a PvE campaign mode that players can progress through.",
+        "categories": ["gaming", "rpg", "reward", "fantasy", "pvp", "p2e"]
       }
     },
     {
@@ -625,7 +670,8 @@
       "logoURI": "https://assets-global.website-files.com/6364e65656ab107e465325d2/65289a7cb687be2bc5173cd6_logo-sticker-blue-1.png",
       "extensions": {
         "link": "https://pooky.gg/",
-        "description": "The Ultimate Fantasy Football Prediction Platform. Predit The Score. Challenge fans worldwide in weekly competitions and win exciting rewards."
+        "description": "The Ultimate Fantasy Football Prediction Platform. Predit The Score. Challenge fans worldwide in weekly competitions and win exciting rewards.",
+        "categories": ["gaming", "reward", "access", "sports"]
       }
     },
     {
@@ -637,7 +683,8 @@
       "logoURI": "https://assets-global.website-files.com/6364e65656ab107e465325d2/65289a7cb687be2bc5173cd6_logo-sticker-blue-1.png",
       "extensions": {
         "link": "https://pooky.gg/",
-        "description": "The Ultimate Fantasy Football Prediction Platform. Predit The Score. Challenge fans worldwide in weekly competitions and win exciting rewards."
+        "description": "The Ultimate Fantasy Football Prediction Platform. Predit The Score. Challenge fans worldwide in weekly competitions and win exciting rewards.",
+        "categories": ["gaming", "sports", "reward", "pvp", "p2e"]
       }
     },
     {
@@ -649,6 +696,7 @@
       "extensions": {
         "link": "https://www.planetmojo.io/",
         "description": "Champions are warriors from the Clans of Planet Mojo. They have been sent to discover the source of the Scourge and determine whether an age-old prophecy is unfolding. In Mojo Melee, most of a player’s team will consist of Champions that have banded together with their Mojo to battle together.",
+        "categories": ["gaming", "art", "reward", "fantasy", "pvp", "p2e"],
         "ogImage": "https://imagedelivery.net/1AztEX5-1VUaJuxpzoqU7A/db516228-8a81-4e58-9782-afb645e76300/public"
       }
     },
@@ -660,7 +708,8 @@
       "logoURI": "https://icodrops.com/wp-content/uploads/2023/05/Sla2HPLX_400x400.jpg",
       "extensions": {
         "link": "https://www.boomland.io/",
-        "description": "BoomLand is Blockchain game developer and publisher with its own NFT marketplace and decentralized ecosystem. Our mission is to push the mass adoption of Web3 gaming by targeting and onboarding traditional Web2 players. Our first game, “Hunters On-Chain”, is a mobile first, multiplayer RPG."
+        "description": "BoomLand is Blockchain game developer and publisher with its own NFT marketplace and decentralized ecosystem. Our mission is to push the mass adoption of Web3 gaming by targeting and onboarding traditional Web2 players. Our first game, “Hunters On-Chain”, is a mobile first, multiplayer RPG.",
+        "categories": ["gaming", "art", "reward", "fantasy", "pvp", "p2e", "rpg"]
       }
     },
     {
@@ -671,7 +720,8 @@
       "logoURI": "https://icodrops.com/wp-content/uploads/2023/05/Sla2HPLX_400x400.jpg",
       "extensions": {
         "link": "https://www.boomland.io/",
-        "description": "BoomLand is Blockchain game developer and publisher with its own NFT marketplace and decentralized ecosystem. Our mission is to push the mass adoption of Web3 gaming by targeting and onboarding traditional Web2 players. Our first game, “Hunters On-Chain”, is a mobile first, multiplayer RPG."
+        "description": "BoomLand is Blockchain game developer and publisher with its own NFT marketplace and decentralized ecosystem. Our mission is to push the mass adoption of Web3 gaming by targeting and onboarding traditional Web2 players. Our first game, “Hunters On-Chain”, is a mobile first, multiplayer RPG.",
+        "categories": ["gaming", "art", "reward", "fantasy", "pvp", "p2e", "rpg"]
       }
     },{
       "chainId": 137,
@@ -681,7 +731,8 @@
       "logoURI": "https://icodrops.com/wp-content/uploads/2023/05/Sla2HPLX_400x400.jpg",
       "extensions": {
         "link": "https://www.boomland.io/",
-        "description": "BoomLand is Blockchain game developer and publisher with its own NFT marketplace and decentralized ecosystem. Our mission is to push the mass adoption of Web3 gaming by targeting and onboarding traditional Web2 players. Our first game, “Hunters On-Chain”, is a mobile first, multiplayer RPG."
+        "description": "BoomLand is Blockchain game developer and publisher with its own NFT marketplace and decentralized ecosystem. Our mission is to push the mass adoption of Web3 gaming by targeting and onboarding traditional Web2 players. Our first game, “Hunters On-Chain”, is a mobile first, multiplayer RPG.",
+        "categories": ["gaming", "rpg", "reward", "fantasy", "p2e"],
       }
     },
     {
@@ -692,7 +743,8 @@
       "symbol": "AMKT Disclosure",
       "logoURI": "https://openseauserdata.com/files/7af3dcf18ed7df35d77afc1a2da0ddcf.jpg",
       "extensions": {
-        "description": "The AMKT disclosure is distributed to holders of the Alongside Crypto Market Index. \n\nAMKT is a [crypto index](https://alongside.xyz/) designed to track the crypto market through exposure to the top 25 assets by market cap. [Learn more about AMKT.](https://alongside.xyz/amkt)"
+        "description": "The AMKT disclosure is distributed to holders of the Alongside Crypto Market Index. \n\nAMKT is a [crypto index](https://alongside.xyz/) designed to track the crypto market through exposure to the top 25 assets by market cap. [Learn more about AMKT.](https://alongside.xyz/amkt)",
+        "categories": ["art", "access", "reward"]
       }
     },
     {
@@ -704,6 +756,7 @@
       "extensions": {
         "link": "https://esportsheroes.gg/#",
         "description": "Be a legend in this first-ever idle RPG in the world of pro esports! Level up your esports athlete, scrim to improve, team up with four other players, and win tournaments on the pro circuit. Live your esports passion!",
+        "categories": ["gaming", "art", "reward", "fantasy", "pvp", "p2e"],
         "ogImage": "https://esportsheroes.gg/assets/hero-bg.jpg"
       }
     },
@@ -716,6 +769,7 @@
       "extensions": {
         "link": "https://esportsheroes.gg/#",
         "description": "Be a legend in this first-ever idle RPG in the world of pro esports! Level up your esports athlete, scrim to improve, team up with four other players, and win tournaments on the pro circuit. Live your esports passion!",
+        "categories": ["gaming", "art", "reward", "fantasy", "pvp", "p2e"],
         "ogImage": "https://esportsheroes.gg/assets/esh_splash.png"
       }
     },{
@@ -728,6 +782,7 @@
       "extensions": {
         "link": "https://www.synergyland.live/",
         "description": "Explore the captivating world of Synergians, our unique collection of PFP NFTs. Each Synergian character boasts distinct traits and personalities.",
+        "categories": ["gaming", "art", "reward", "fantasy", "p2e"],
         "ogImage": "https://storage.googleapis.com/sequence-prod-cluster-builder/projects/1977/landingBannerUrl/2ecae86ff91114e20330401b0d5d1cecd7c94ead6629b1dcf0e364395ec1fb93.png"
       }
     } , {
@@ -740,6 +795,7 @@
       "extensions": {
         "link": "https://www.synergyland.live/",
         "description": "Unlock exclusive benefits and privileges with Synergian Badges, a collection of NFTs designed to elevate your status within the Synergy Land community. Showcase your achievements, loyalty, and contributions with these prestigious badges.",
+        "categories": ["gaming", "reward", "access", "fantasy"],
         "ogImage": "https://storage.googleapis.com/sequence-prod-cluster-builder/projects/1973/landingBannerUrl/198b5fa3f184fd3a2f7defdd599ee1aa1b2e3272f80489964ead6add81053876.png"
       }
     },
@@ -753,6 +809,7 @@
       "extensions": {
         "link": "https://www.synergyland.live/",
         "description": "Meet your loyal companions in Synergy Land, a collection of creatures ready to join you on your journey. From fierce warriors to adorable companions, these pets offer unique abilities and companionship as you navigate the vast landscapes of Synergy Land.",
+        "categories": ["gaming", "art", "reward", "fantasy", "p2e"],
         "ogImage": "https://storage.googleapis.com/sequence-prod-cluster-builder/projects/1976/landingBannerUrl/597ed9bf0b670cd4dbc7fa654459b483cbe9333dd26e6449f6ff315e855e4d22.png"
       }
     },
@@ -766,6 +823,7 @@
       "extensions": {
         "link": "https://www.synergyland.live/",
         "description": "Get a head start on your adventures with the Furya Starter Pack. This curated collection of NFTs provides essential tools, resources, and boosts to kickstart your journey in Synergy Land.",
+        "categories": ["gaming", "art", "reward", "fantasy", "p2e"],
         "ogImage": "https://storage.googleapis.com/sequence-prod-cluster-builder/projects/1974/landingBannerUrl/447402593e5aa8c859a0cd1767da37bf27401d1416385d8e25635b71cb2a6ba7.png"
       }
     },
@@ -779,6 +837,7 @@
       "extensions": {
         "link": "https://symbiogenesis.app/",
         "description": "Square Enix Global NFT Collectible Art Project - SYMBIOGENESIS - 10,000 collectible artworks meet real game utility.\n\nGame Utility\nThis game's genre is defined as 'Narrative-unlocked NFT entertainment' \n As you unlock the main story, as well as the individual stories of each character, unravel the mysteries of the world.\n\nThe chip-like relics contain Allowlist points for chapter 1 but do not contain any in-game utility",
+        "categories": ["gaming", "art", "reward", "access"],
         "ogImage": "https://i.seadn.io/gcs/files/6f2a6fad6c7a160de029413524f3a23c.png?auto=format&dpr=1&w=384"
       }
     }       

--- a/index/rinkeby/erc1155.json
+++ b/index/rinkeby/erc1155.json
@@ -16,6 +16,7 @@
       "extensions": {
         "link": "https://www.skyweaver.net/",
         "description": "Skyweaver is a Free-to-Play, trading card game powered by Polygon and Ethereum.",
+        "categories": ["gaming", "tcg", "skyweaver"],
         "ogImage": "https://skyweaver.net/images/skyweavercover.jpg",
         "originChainId": 4,
         "originAddress": "0x631998e91476DA5B870D741192fc5Cbc55F5a52E",
@@ -32,6 +33,7 @@
       "extensions": {
         "link": "https://dev.fractional.art/",
         "description": "Fractional ownership of the world’s most sought after NFTs. Fractional reduces entry costs, increases access, and enables new communities.",
+        "categories": ["art", "rwa", "transactional"],
         "ogImage": "https://assets.fractional.art/media/placeholder.png",
         "originChainId": 4,
         "originAddress": "0xc2e78eff7b3862356968bf24b9e89b265552a62f"
@@ -47,6 +49,7 @@
       "extensions": {
         "link": "https://testnets.opensea.io/collection/exquisite-art",
         "description": "Exquisite Art is a collection of pixel artwork inspired by projects on Ethereum, created by @scotato.",
+        "categories": ["art"],
         "ogImage": "https://lh3.googleusercontent.com/IErZEkAbINAsjep9RmAkAzHfLI6U1YpOtX_EH6K8Q4dAX1BgA9p_vtgw3CDASrICxDve5E_R0GV9VX8tN_-Et49Jeb3WcCm2Ys0BtcA=s0",
         "originChainId": 4,
         "originAddress": "0x6cf6afcaad7a5af1e0c46da135c49b0721e39c42"
@@ -58,7 +61,8 @@
       "name": "Donut Official",
       "standard": "erc1155",
       "extensions": {
-        "blacklist": true
+        "blacklist": true,
+        "categories": ["art", "meme"]
       }
     }
   ],

--- a/index/rinkeby/erc20.json
+++ b/index/rinkeby/erc20.json
@@ -16,6 +16,7 @@
       "extensions": {
         "link": "https://www.circle.com/en/usdc",
         "description": "TEST CURRENCY, NOT THE REAL USDC. USDC is a token tracking the price of 1 USD.",
+        "categories": ["usd-stablecoin", "transactional", "usdc"],
         "ogImage": "https://www.circle.com/hubfs/share-USDC.png#keepProtocol",
         "originChainId": 4,
         "originAddress": ""
@@ -31,7 +32,8 @@
       "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
       "extensions": {
         "link": "https://weth.io/",
-        "description": "W-ETH is \"wrapped ETH\" but let's start by introducing the players. First, there's Ether token. Ether or ETH is the native currency built on the Ethereum blockchain.\r\nSecond, there are alt tokens. When a dApp (decentralized app) is built off of the Ethereum Blockchain it usually implements it’s own form of Token. Think Augur’s REP Token, or Bancor's BNT Token. Finally the ERC-20 standard. ERC20 is a standard developed after the release of ETH that defines how tokens are transferred and how to keep a consistent record of those transfers among tokens in the Ethereum Network."
+        "description": "W-ETH is \"wrapped ETH\" but let's start by introducing the players. First, there's Ether token. Ether or ETH is the native currency built on the Ethereum blockchain.\r\nSecond, there are alt tokens. When a dApp (decentralized app) is built off of the Ethereum Blockchain it usually implements it’s own form of Token. Think Augur’s REP Token, or Bancor's BNT Token. Finally the ERC-20 standard. ERC20 is a standard developed after the release of ETH that defines how tokens are transferred and how to keep a consistent record of those transfers among tokens in the Ethereum Network.",
+        "categories": ["defi", "protocol", "chain", "wrapped"]
       }
     }
   ],

--- a/index/rinkeby/erc721.json
+++ b/index/rinkeby/erc721.json
@@ -12,7 +12,8 @@
       "name": "Coworker Cats",
       "standard": "erc721",
       "extensions": {
-        "blacklist": true
+        "blacklist": true,
+        "categories": ["art", "meme"]
       }
     }
   ],

--- a/index/rinkeby/misc.json
+++ b/index/rinkeby/misc.json
@@ -12,6 +12,9 @@
       "standard": "niftyswap20",
       "symbol": "SWAP",
       "logoURI": "https://assets.skyweaver.net/latest/sw-swap.png"
+      "extensions": {
+        "categories": ["exchange", "transactional", "art", "skyweaver"]
+      }
     }
   ]
 }

--- a/index/rinkeby/misc.json
+++ b/index/rinkeby/misc.json
@@ -11,7 +11,7 @@
       "name": "Skyweaver Niftyswap",
       "standard": "niftyswap20",
       "symbol": "SWAP",
-      "logoURI": "https://assets.skyweaver.net/latest/sw-swap.png"
+      "logoURI": "https://assets.skyweaver.net/latest/sw-swap.png",
       "extensions": {
         "categories": ["exchange", "transactional", "art", "skyweaver"]
       }


### PR DESCRIPTION
Worked through every indexer JSON token entry and added a new `categories` array (and `extensions` object if necessary) for [Issue #3715](https://github.com/0xsequence/issue-tracker/issues/3715). Identified the type/utilities of each token and determined categories to include from the initial [standardized list](https://docs.google.com/spreadsheets/d/1gQu4zXI46n9MmSJ-G-cpkM1bLva2AXVW8sSy-y6ot1I/edit?usp=sharing) I created beforehand. Every token received as many category tags as applicable from column A, while only gaming, art, and sometimes gambling related projects received further genre tags from column B within the same `categories` array. Initial tags were also included to easily identify whole ecosystems such as Maker or Synthetix.

The ERC-20, ERC-1155, ERC-721, and misc JSONs have been completed for every chain besides mainnet. Each of mainnet's JSONs includes more entries than nearly every other chain combined so will take a while before being pushed as a 2nd PR. Polygon is the 2nd most extensive and was prioritized being already indexed. 

Pushing before mainnet completion to prevent Marcin from being blocked and to enable testing with real data.