### PR TITLE
fix: correct KAT token address on Ethereum mainnet

### DIFF
--- a/index/mainnet/erc20.json
+++ b/index/mainnet/erc20.json
@@ -25531,7 +25531,7 @@
     },
     {
       "chainId": 1,
-      "address": "0xD5390300c5DB71F80d46f0fA9983Fc72D4d1e3da",
+      "address": "0x8F051Ca72a3440d83B18E71C3E59676203aB8f91",
       "name": "Katana Network Token",
       "symbol": "KAT",
       "decimals": 18,


### PR DESCRIPTION
## Summary
- Fix incorrect KAT token address on Ethereum mainnet
- Was using Base chain KAT address (`0xD5390300c5DB71F80d46f0fA9983Fc72D4d1e3da`) instead of the correct Ethereum mainnet KAT OFT contract (`0x8F051Ca72a3440d83B18E71C3E59676203aB8f91`)
- This caused LZ_OFT bridge quotes for Katana KAT ↔ Ethereum KAT to fail with "route not supported" because the destination token address didn't match

## Test plan
- [ ] Verify Katana KAT → Ethereum KAT quote works on dev after deploy
- [ ] Verify Ethereum KAT → Katana KAT quote works on dev after deploy