### PR TITLE
feat: add HEDGE token (Hedgehog Protocol) on Sonic

### DIFF
--- a/index/index.json
+++ b/index/index.json
@@ -316,7 +316,7 @@
     "sonic": {
       "chainId": 146,
       "tokenLists": {
-        "erc20.json": "575d1610c4de7b9139023c82c0bac301cd8a3edd57be306e29453a2850016c7c"
+        "erc20.json": "c7ae07b87bb9a65cf1a38ec7bb464e845ea6e066fa631bedc0fc85d04f2aa7ed"
       }
     }
   }

--- a/index/sonic/erc20.json
+++ b/index/sonic/erc20.json
@@ -3,7 +3,12 @@
   "chainId": 146,
   "tokenStandard": "erc20",
   "logoURI": "",
-  "keywords": ["erc20", "fungible", "stablecoin", "coingecko"],
+  "keywords": [
+    "erc20",
+    "fungible",
+    "stablecoin",
+    "coingecko"
+  ],
   "timestamp": "2025-09-01T00:00:00.000Z",
   "tokens": [
     {
@@ -76,6 +81,19 @@
       "extensions": {
         "featured": true,
         "featureIndex": 4
+      }
+    },
+    {
+      "chainId": 146,
+      "address": "0x5cccebcb0c0af721a6539afda1628eeaaf7d6c5c",
+      "name": "Hedge Token",
+      "symbol": "HEDGE",
+      "decimals": 18,
+      "logoURI": "https://i.imgur.com/IXYOX7V.png",
+      "extensions": {
+        "link": "https://sonicpump.meme",
+        "description": "Native token of Hedgehog Protocol, a permissionless meme token launchpad on Sonic with bonding curve liquidity.",
+        "ogImage": null
       }
     }
   ],


### PR DESCRIPTION
## Summary

Adds the HEDGE token from Hedgehog Protocol to the Sonic ERC-20 token list.

**Token Details:**
- Name: Hedge Token
- Symbol: HEDGE
- Contract: `0x5cccebcb0c0af721a6539afda1628eeaaf7d6c5c`
- Decimals: 18
- Chain ID: 146 (Sonic)

**Protocol:** [Hedgehog Protocol](https://sonicpump.meme) — permissionless meme token launchpad on Sonic with bonding curve liquidity. Tokens launched via the protocol are real ERC-20s with permanent on-chain liquidity.

**Links:**
- Website: https://sonicpump.meme
- Twitter: https://x.com/sonicpumpmeme
- SonicScan: https://sonicscan.org/token/0x5cccEbCb0C0af721a6539aFDa1628EeaAF7d6C5c