### PR TITLE
feat: add WSOMI to Somnia token list

### DIFF
--- a/index/index.json
+++ b/index/index.json
@@ -310,7 +310,7 @@
     "somnia": {
       "chainId": 5031,
       "tokenLists": {
-        "erc20.json": "af75d3d62197831c65946fe26e351a64e065b8fff1f320e270e1a7a72f95f493"
+        "erc20.json": "2ce1ba83ef74eaa1ef4b22bf310c964839a891dcbe624e566271831b09c3b156"
       }
     },
     "soneium": {

--- a/index/somnia/erc20.json
+++ b/index/somnia/erc20.json
@@ -77,6 +77,18 @@
         "featured": true,
         "featureIndex": 4
       }
+    },
+    {
+      "chainId": 5031,
+      "address": "0x046EDe9564A72571df6F5e44d0405360c0f4dCab",
+      "name": "Wrapped SOMI",
+      "symbol": "WSOMI",
+      "decimals": 18,
+      "logoURI": "https://assets.sequence.info/images/tokens/large/5031/0x0000000000000000000000000000000000000000.webp",
+      "extensions": {
+        "featured": true,
+        "featureIndex": 5
+      }
     }
   ],
   "version": {


### PR DESCRIPTION
## Summary
- Adds Wrapped SOMI (WSOMI) token (`0x046EDe9564A72571df6F5e44d0405360c0f4dCab`) to the Somnia ERC-20 token list
- WSOMI is the wrapped native token used by the `SOMNIA_EXCHANGE` swap provider in trails-api for `USDC.e <-> WSOMI` swaps
- Without this entry, QuoteIntent fails to discover/price WSOMI as a swap destination

## Test plan
- [ ] Verify `pnpm run reindex` produces matching hash in `index.json`
- [ ] Verify trails-api `QuoteIntent` works for USDC.e -> WSOMI on Somnia after token-directory cache refresh