### PR TITLE
fix: set Somnia chain logo to new branding

### DIFF
--- a/index/index.json
+++ b/index/index.json
@@ -310,7 +310,7 @@
     "somnia": {
       "chainId": 5031,
       "tokenLists": {
-        "erc20.json": "ef1de7793ff725c3160e331419fc7b217eac740f4cb6eb4485acb3e61f025ecb"
+        "erc20.json": "a12e68c49e11843b91a4efa4b2e435d1f9c9d9788d065d0f1707dc35ddc95a58"
       }
     },
     "soneium": {

--- a/index/somnia/erc20.json
+++ b/index/somnia/erc20.json
@@ -2,7 +2,7 @@
   "name": "sequence-erc20-somnia",
   "chainId": 5031,
   "tokenStandard": "erc20",
-  "logoURI": "",
+  "logoURI": "https://raw.githubusercontent.com/0xsequence/token-directory/master/index/somnia/logos/somi.png",
   "keywords": ["erc20", "fungible", "stablecoin"],
   "timestamp": "2026-05-12T00:00:00.000Z",
   "tokens": [


### PR DESCRIPTION
## Summary
- Set the list-level `logoURI` in `index/somnia/erc20.json` to the new `{s}` branding logo
- PR #145 updated token logos but left the chain-level logo empty

## Test plan
- [ ] Verify the `logoURI` field at the top of `index/somnia/erc20.json` points to the correct somi.png
- [ ] Confirm the logo renders correctly in consumers of this token list