### PR TITLE
ci: sync ./index/ to GCS on merge to master

### DIFF
--- a/.github/workflows/sync-index-gcs.yml
+++ b/.github/workflows/sync-index-gcs.yml
@@ -1,0 +1,45 @@
+name: Sync index to GCS
+
+on:
+  push:
+    branches: [master]
+  # Manual trigger for re-syncs / testing (remove if you want strictly merge-only)
+  workflow_dispatch:
+
+# Queue concurrent runs instead of letting two syncs interleave
+concurrency:
+  group: gcs-index-sync
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  GCS_BUCKET: token-directory-index
+  # Remote prefix, so files land at gs://<bucket>/index/...
+  GCS_PREFIX: index
+
+jobs:
+  sync-index:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          # Secret containing the full service account JSON key
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Sync ./index/ to GCS
+        # --delete removes remote objects that no longer exist locally,
+        # so the bucket stays an exact mirror of ./index/
+        run: gcloud storage rsync ./index/ "gs://${GCS_BUCKET}/${GCS_PREFIX}/" --delete
+
+      - name: Verify public index.json
+        run: |
+          curl -fsS "https://storage.googleapis.com/${GCS_BUCKET}/${GCS_PREFIX}/index.json" -o /tmp/index.json
+          diff -q ./index/index.json /tmp/index.json && echo "GCS copy matches local index.json"

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 node_modules
 tools/node_modules
 tools/config/creds.env
+gcp-sa-key.json
 yarn-error.log


### PR DESCRIPTION
Adds a GitHub Action that mirrors ./index/ to the public GCS bucket (token-directory-index) on every merge to master.

- Uses gcloud storage rsync --delete so the bucket stays an exact mirror (stale files removed)
- Auth via GCP_SA_KEY secret (service account scoped to objectAdmin on this bucket only)
- Concurrency group to queue back-to-back syncs
- Post-sync verification: curls the public index.json and diffs against the repo copy
- Adds gcp-sa-key.json to .gitignore

Requires the GCP_SA_KEY repo secret to be set before the first run.