### PR TITLE
fix(ci): use gsutil rsync for GCS sync

### DIFF
--- a/.github/workflows/sync-index-gcs.yml
+++ b/.github/workflows/sync-index-gcs.yml
@@ -31,13 +31,13 @@ jobs:
           # Secret containing the full service account JSON key
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
-      - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v2
+      - name: Install gsutil
+        run: pip install -U gsutil
 
       - name: Sync ./index/ to GCS
-        # --delete removes remote objects that no longer exist locally,
+        # -d deletes remote objects that no longer exist locally,
         # so the bucket stays an exact mirror of ./index/
-        run: gcloud storage rsync ./index/ "gs://${GCS_BUCKET}/${GCS_PREFIX}/" --delete
+        run: gsutil -m rsync -r -d ./index/ "gs://${GCS_BUCKET}/${GCS_PREFIX}/"
 
       - name: Verify public index.json
         run: |


### PR DESCRIPTION
The first run failed with `unrecognized arguments: --delete` — `gcloud storage rsync` does not support a delete flag.

Switches the sync step to `gsutil -m rsync -r -d`, which has true sync semantics (`-d` deletes remote objects no longer present locally). Also drops the now-unneeded `setup-gcloud` step — gsutil reads the service account credentials directly from `GOOGLE_APPLICATION_CREDENTIALS` set by the auth action.