### PR TITLE
fix(ci): gcloud storage rsync with correct delete flag

### DIFF
--- a/.github/workflows/sync-index-gcs.yml
+++ b/.github/workflows/sync-index-gcs.yml
@@ -31,13 +31,13 @@ jobs:
           # Secret containing the full service account JSON key
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
-      - name: Install gsutil
-        run: pip install -U gsutil
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
 
       - name: Sync ./index/ to GCS
-        # -d deletes remote objects that no longer exist locally,
-        # so the bucket stays an exact mirror of ./index/
-        run: gsutil -m rsync -r -d ./index/ "gs://${GCS_BUCKET}/${GCS_PREFIX}/"
+        # --delete-unmatched-destination-objects removes remote objects that no
+        # longer exist locally, so the bucket stays an exact mirror of ./index/
+        run: gcloud storage rsync ./index/ "gs://${GCS_BUCKET}/${GCS_PREFIX}/" --recursive --delete-unmatched-destination-objects
 
       - name: Verify public index.json
         run: |


### PR DESCRIPTION
Turns out `gcloud storage rsync` **does** support destination deletion — the flag is `--delete-unmatched-destination-objects` (not `--delete`).

- Reverts from the gsutil workaround (which hit an unrelated urllib3 2.x incompatibility with gsutil's HTTP layer) back to the official gcloud CLI
- Syncs `./index/` → `gs://token-directory-index/index/` with `--recursive --delete-unmatched-destination-objects` (mirror semantics: removes remote objects no longer in the repo)
- Verified flag exists in the installed gcloud: `gcloud storage rsync --help` lists `--delete-unmatched-destination-objects`

Also confirmed from the official docs: https://cloud.google.com/sdk/gcloud/reference/storage/rsync