### PR TITLE
chore: flag fee-on-transfer tokens on mainnet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 node_modules
 tools/node_modules
 tools/config/creds.env
+tools/.fee-on-transfer-cache.*
 yarn-error.log

--- a/index/index.json
+++ b/index/index.json
@@ -207,7 +207,7 @@
       "chainId": 1,
       "tokenLists": {
         "erc1155.json": "05a4b8873fcb7ae59997e4381a1b7470dd9bcc6120ed4f7d331f751cc1af519a",
-        "erc20.json": "12350fb8763dc76cecf2154fb701abfd0b9e773ee2470005a6e04bfa0350748b",
+        "erc20.json": "d5c0c6716a860b07052ada8c2115df0c6894285f7b7cc701fef081ce91c9081c",
         "erc721.json": "8e6349df6152d116602a6626909083d8a97892b981a42ca8470db6670d3da66d",
         "misc.json": "f98a5ccf5fa208e0861c020ad16b44adfafff42d8f359fa94e6701a7397b1e92"
       }

--- a/index/mainnet/erc20.json
+++ b/index/mainnet/erc20.json
@@ -3790,7 +3790,8 @@
       "extensions": {
         "link": "http://digix.io/",
         "description": "DIGIX DAO TOKENS. Our vision for the future is a world operating on Smart Contracts. Indeed, we think this vision will become a reality very soon.\r\nIn this world, a stable store of value is needed - that's why we created DGX.\r\nIn order to ensure the success of DGX, we also conceived DGD; a stake in a 'Distributed Autonomous Organisation' that rewards DGD holders based on DGX's success. By participating in the DAO and working on its behalf in curating proposals, you get rewarded based on the usage of DGX in the Ethereum ecosystem.\r\nDGD holders use their tokens to decide on proposals, and determine the best way forward for Digix.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -5453,7 +5454,8 @@
       "extensions": {
         "link": "https://www.bombtoken.com",
         "description": "The world's first self-destructing currency.\r\n\r\nBOMB is a social experiment and financial case study to measure the feasibility of a deflationary currency.  The rules are simple.\r\n\r\n1) There were originally 1,000,000 Bomb in existence.\r\n\r\n2) Each time a Bomb is transferred, 1% of the transaction is destroyed.\r\n\r\n3) There will never be newly minted Bomb.\r\n\r\nThe intention is not to be used as a transactional currency, but rather a consistent and decentralized store of value. Through a system of immutable smart contracts and continuous hyperdeflation, BOMB is the world’s first self-destructing currency.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -6209,7 +6211,8 @@
       "extensions": {
         "link": "https://doyourtip.io/",
         "description": null,
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -6222,7 +6225,8 @@
       "extensions": {
         "link": "https://fuzetoken.net",
         "description": "What is FUZE?\r\nFUZE Token is a fully community-driven social experiment and the world’s first self-deflationary currency with a supply of 1000 tokens and a 5% burn rate.\r\n\r\nWhy FUZE?\r\nA difference between FUZE and most other deflationary projects is that there is no dev holding/allocation — every token was distributed fairly by airdrops. This distinguishes FUZE as a token created entirely for its community.\r\n\r\nWhat’s the purpose of the FUZE project?\r\nOur main goal is to build a community that decides in which direction the FUZE Token should go. Future functions or use-cases can be built by any member of the community. Of course, the main function right now is the deflationary token model — this means the total supply decreases with each transaction.\r\n\r\nWhy a deflationary token?\r\nWe like the concept of this kind of token model because it exemplifies the hodler mentality. Let’s say you buy FUZE Tokens for 1 ETH — you are incentivized to hold your FUZE because each time you send it to ...",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -6365,7 +6369,8 @@
       "extensions": {
         "link": "https://superblackhole.com/",
         "description": "HOLE is a hyperdeflationary cryptocurrency with massive 20% burn. Join us on the journey to the unknown parts of the universe.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -6443,7 +6448,8 @@
       "extensions": {
         "link": "https://www.btcsov.com/",
         "description": "BitcoinSoV: A Proof of Work Decentralized, Fungible, Censorship Free, Deflationary Currency. Providing any one in the world with a true Store of Value protected from inflation. BitcoinSov is mined using a simple Keccak256 (Sha3) algorithm. There is No ICO, No Pre-mine, and No Governance. This allows for BSoV to be completely decentralized and fairly distributed. With each transfer of BSoV tokens, 1% of the total transaction is burned forever. ",
-        "ogImage": "https://bsov.io/wp-content/uploads/2019/11/claim-your-right.jpg"
+        "ogImage": "https://bsov.io/wp-content/uploads/2019/11/claim-your-right.jpg",
+        "feeOnTransfer": true
       }
     },
     {
@@ -6456,7 +6462,8 @@
       "extensions": {
         "link": "https://shuffle.monster/",
         "description": "The Shuffle Monster token is an experimental ERC20 token that shuffles 1% of each token transfer, and burns another 1%.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -6899,7 +6906,8 @@
       "extensions": {
         "link": "https://zum-token.com/",
         "description": "The encryption currency used in special tournaments for  games.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -7135,7 +7143,8 @@
       "extensions": {
         "link": "https://brainiacchess.network/",
         "description": "Chess Coin is our platform digital currency that will be used as means of incentives to chess players that use our platform.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -7525,7 +7534,8 @@
       "extensions": {
         "link": "https://pyro.network/",
         "description": "The PYRO.NETWORK is a series of projects including but not limited to a social network, digital advertising network and blockchain gaming dApp platform which will utilize PYRO.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -8776,7 +8786,8 @@
       "extensions": {
         "link": "https://vetherasset.io/",
         "description": "A strictly-scarce Ethereum-based asset.\r\nVether is designed to be a store-of-value with properties of strict scarcity, unforgeable costliness and a fixed emission schedule. Vether mimics characteristics of Bitcoin, where miners compete to expend capital to acquire newly-minted coins and chase ever-decreasing margins. Instead of expending capital, Vether participants compete to purchase it by destroying capital on-chain. As a result, all units of Vether are acquired at-cost and by anyone. This mechanism is called Proof-of-Value.",
-        "ogImage": "https://vetherasset.io/screenshot.png"
+        "ogImage": "https://vetherasset.io/screenshot.png",
+        "feeOnTransfer": true
       }
     },
     {
@@ -8828,7 +8839,8 @@
       "extensions": {
         "link": "https://stateratoken.com/",
         "description": "An Ethereum smart-contract token with a difference\r\n\r\nDeflationary\r\nStatera's core algorithm is designed to ensure that for every transaction, 1% of the amount transacted is destroyed.\r\n\r\nExchange\r\nSmart-exchange routing, including, but not limited to, Kyber, 0x Relays, Uniswap, Balancer & 1inch.\r\n\r\nPortfolio\r\nConstant arbitrage trading opportunities keep Statera's portfolio weights and tokens in a constant ratio.\r\n\r\n\r\nStatera rebalacing\r\nEvery trade for Statera creates an arbitrage opportunity. Trading attracts liquidity, which in-turn attracts trading. Liquidity ripples and the supply of Statera decreases.\r\n\r\n'statera' is derived from the Latin word for 'balance'",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -9023,7 +9035,8 @@
       "extensions": {
         "link": "https://pamp.network/",
         "description": "The Pamp Network is the world's first price-reactive cryptocurrency. The PAMP token smart contract rewards holders when the price inreases and penalizes sellers when it does not.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -9036,7 +9049,8 @@
       "extensions": {
         "link": "https://h3x.exchange/",
         "description": "H3X is the first variable length certificate of deposit staking token",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -9192,7 +9206,8 @@
       "extensions": {
         "link": "https://www.flamanet.io/",
         "description": null,
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -9310,7 +9325,8 @@
       "extensions": {
         "link": "https://unidollar.network",
         "description": "UniDollar is the first hybrid Proof of Liquidity and Proof of Stake ERC20 Token",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -9375,7 +9391,8 @@
       "extensions": {
         "link": "https://freelancerchain.com/",
         "description": "FreelancerChain is a new-generation Blockchain-powered freelance platform where any freelancer throughout the world can find a job and receive payment. Our primary objective is, with the support of Blockchain, to ensure a reliable, fast, and a low-commission payment with FCN tokens between the freelancer and the client.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -9479,7 +9496,8 @@
       "extensions": {
         "link": "https://burndrop.net",
         "description": "An ERC-20 token that is being massively airdropped and has a 5% burn in each transaction.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -9492,7 +9510,8 @@
       "extensions": {
         "link": "https://crypt-id.com",
         "description": "The official utility token of the Crypt-id project, the first cryptocurrency for the greater esoteric community.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -9518,7 +9537,8 @@
       "extensions": {
         "link": "https://rainnetwork.online/",
         "description": "RAIN Network is a Decentralized Autonomous Rewards Platform with built in Proof of Stake (PoS) functionality in its smart contract, charging a 1% tax on all transfers which is distributed proportionately to all stakers.",
-        "ogImage": "https://i.imgur.com/m19HC0d.jpg"
+        "ogImage": "https://i.imgur.com/m19HC0d.jpg",
+        "feeOnTransfer": true
       }
     },
     {
@@ -9700,7 +9720,8 @@
       "extensions": {
         "link": "https://askobar-network.com",
         "description": "Revolutionizing Proof of Locked Liquidity. Askobar network uses a suite of innovative smart contracts to provide the next level of security to decentralized finance.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -10104,7 +10125,8 @@
       "extensions": {
         "link": "https://fireball.network/",
         "description": "Fireball is an autonomous staking rewards and gaming platform.\r\nFireball (FIRE), an ERC20 deflationary token meant to reward stakers on fireball staking platform.\r\nEach time a transaction occur 10% is deducted as fee, 5% is burnt and 5% goes to Stakers.\r\nWhen any Staker unstake before 30 days, 20% is deducted as impatient fee and distributed to Stakers.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -10117,7 +10139,8 @@
       "extensions": {
         "link": "https://zom.health",
         "description": "ZOM is a digital currency that embodies a pledge-protocol approach in which ZOM tokens are collateralized in order to connect people with healthcare providers.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -10260,7 +10283,8 @@
       "extensions": {
         "link": "https://www.lid.sh",
         "description": "Licensed Proof of Locked Liquidity solutions for pre-sales and DEX launches.",
-        "ogImage": "/static/opengraph.png"
+        "ogImage": "/static/opengraph.png",
+        "feeOnTransfer": true
       }
     },
     {
@@ -10338,7 +10362,8 @@
       "extensions": {
         "link": "https://www.cybercoin.site/",
         "description": "The CYBERCOIN is a series of projects including but not limited to a social network, digital advertising network and blockchain dApp platform which will utilize CYBERCOIN, an ERC20 deflationary and staking token.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -10404,7 +10429,8 @@
       "extensions": {
         "link": "https://bonktoken.com/",
         "description": null,
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -10534,7 +10560,8 @@
       "extensions": {
         "link": "https://www.flashxcoinofficial.com/",
         "description": "FlashX Advance is the first dapp of FlashX Coin and a staking dapp with burning mechanism.",
-        "ogImage": "https://static.wixstatic.com/media/7e167b_6a0b559eb78a4fa2bd5d747ed12dc621~mv2.png/v1/fill/w_631,h_631,al_c/7e167b_6a0b559eb78a4fa2bd5d747ed12dc621~mv2.png"
+        "ogImage": "https://static.wixstatic.com/media/7e167b_6a0b559eb78a4fa2bd5d747ed12dc621~mv2.png/v1/fill/w_631,h_631,al_c/7e167b_6a0b559eb78a4fa2bd5d747ed12dc621~mv2.png",
+        "feeOnTransfer": true
       }
     },
     {
@@ -10742,7 +10769,8 @@
       "extensions": {
         "link": "https://loanburst.co",
         "description": "Loanburst is a deflationary reward system where loans locked are rewarded through every sell, buy and transactions on the smart contract.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -10833,7 +10861,8 @@
       "extensions": {
         "link": "https://frens.link/",
         "description": "Smart contract where frens from all over the world can come together to stake and have some steaks.\r\n\r\nThis is a fork from Kek with a burn mechanism added to control inflation and developer's ability to mint removed",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -10859,7 +10888,8 @@
       "extensions": {
         "link": "https://mammothgames.io",
         "description": "Deflationary, profit sharing token of Mammoth Corp project.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -11003,7 +11033,8 @@
       "extensions": {
         "link": "https://myx.network/",
         "description": "MYX Network is a DeFi Deflationary and Staking ERC20 token which is the primary digital asset of MYX Protocol which includes a Digital Advertisement Network, Investor DAO and Social Media Network.",
-        "ogImage": "https://i.imgur.com/NCyvdpc.jpg"
+        "ogImage": "https://i.imgur.com/NCyvdpc.jpg",
+        "feeOnTransfer": true
       }
     },
     {
@@ -11238,7 +11269,8 @@
       "extensions": {
         "link": "https://www.porkchop.network/",
         "description": "A hyper deflationary burn to earn rewards network.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -11251,7 +11283,8 @@
       "extensions": {
         "link": "https://spaghetti.money/",
         "description": null,
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -11810,7 +11843,8 @@
       "extensions": {
         "link": "https://handsofsteel.money/",
         "description": "Our Seller Transfer Only Protocol Initiates Tax (STOP IT) actively taxes sellers while rewarding holders.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -11823,7 +11857,8 @@
       "extensions": {
         "link": "https://www.blazenetwork.online/",
         "description": "Blaze Network is a deflationary token which burns 2% on each transaction. It has a unique usercase which other deflationary don't have.",
-        "ogImage": "https://static.wixstatic.com/media/7e167b_7c861f467aee4f8bbdadff86e63a34fe~mv2.png/v1/fill/w_512,h_512,al_c/7e167b_7c861f467aee4f8bbdadff86e63a34fe~mv2.png"
+        "ogImage": "https://static.wixstatic.com/media/7e167b_7c861f467aee4f8bbdadff86e63a34fe~mv2.png/v1/fill/w_512,h_512,al_c/7e167b_7c861f467aee4f8bbdadff86e63a34fe~mv2.png",
+        "feeOnTransfer": true
       }
     },
     {
@@ -11849,7 +11884,8 @@
       "extensions": {
         "link": "https://boa-token.webflow.io",
         "description": "Game token linked with TOB-XAMP. BOA Taxes sellers, rewards hodlers",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -11927,7 +11963,8 @@
       "extensions": {
         "link": "https://rockettoken.net/",
         "description": null,
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -12201,7 +12238,8 @@
       "extensions": {
         "link": "https://walnut.finance/",
         "description": null,
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -12266,7 +12304,8 @@
       "extensions": {
         "link": "https://rug.money/",
         "description": "A community driven experiment that redistributes wealth to the bold.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -12539,7 +12578,8 @@
       "extensions": {
         "link": "https://defibids.com",
         "description": null,
-        "ogImage": "http://img1.wsimg.com/isteam/ip/876dce87-e38d-457f-a6bc-4458a267f2ce/IMG_20200919_115011_935.png"
+        "ogImage": "http://img1.wsimg.com/isteam/ip/876dce87-e38d-457f-a6bc-4458a267f2ce/IMG_20200919_115011_935.png",
+        "feeOnTransfer": true
       }
     },
     {
@@ -12877,7 +12917,8 @@
       "extensions": {
         "link": "https://www.mafi.network/",
         "description": "A hyper deflationary cryptocurrency game in which ​it pays to be in the family. ",
-        "ogImage": "https://www.mafi.network/uploads/1/3/3/5/133540166/supply-demand_orig.png"
+        "ogImage": "https://www.mafi.network/uploads/1/3/3/5/133540166/supply-demand_orig.png",
+        "feeOnTransfer": true
       }
     },
     {
@@ -12981,7 +13022,8 @@
       "extensions": {
         "link": "https://maki.finance",
         "description": null,
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -13033,7 +13075,8 @@
       "extensions": {
         "link": "https://popcorntoken.dev",
         "description": "Popcorn (CORN) is an ERC20 token, the new social experiment, fun and meme machine rolled onto Ethereum blockchain. It’s the most enjoyable fun you can have with ERC20 while getting some reward. Who wouldn’t want to get rewarded for having fun? Let's have some rewarding fun.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -13189,7 +13232,8 @@
       "extensions": {
         "link": "https://sherlocksecurity.io/",
         "description": "SherLOCK Security is a decentralized liquidity custody, audit group, token sale organizing service, dapp incubator and secure launchpad for new projects.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -13423,7 +13467,8 @@
       "extensions": {
         "link": "https://ymen.finance/",
         "description": null,
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -13462,7 +13507,8 @@
       "extensions": {
         "link": "https://chads.vc",
         "description": "The CHADS token is a social experiment designed to teach virgins how to trade like a chad.  It is a deflationary coin utilizing a novel burn curve mechanism. The lower the price you sell or transfer CHADS, the more of your tokens are burnt.",
-        "ogImage": "https://static.wixstatic.com/media/46216d_0e57f12f09f04da9905ae725b5be9b06%7Emv2.png/v1/fit/w_2500,h_1330,al_c/46216d_0e57f12f09f04da9905ae725b5be9b06%7Emv2.png"
+        "ogImage": "https://static.wixstatic.com/media/46216d_0e57f12f09f04da9905ae725b5be9b06%7Emv2.png/v1/fit/w_2500,h_1330,al_c/46216d_0e57f12f09f04da9905ae725b5be9b06%7Emv2.png",
+        "feeOnTransfer": true
       }
     },
     {
@@ -13514,7 +13560,8 @@
       "extensions": {
         "link": "https://www.xmmtoken.com",
         "description": "Dynamic Deflationary Token",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -13527,7 +13574,8 @@
       "extensions": {
         "link": "https://tributedefi.com/",
         "description": "TRIBUTE is a DeFi ecosystem developed with focus on community empowerment and game theory analysis. The TRIBUTE community will shape how the project evolves and will be involved in the study of the interplay between TRIBUTE's deflationary token and the native dapps as well as their role in the larger DeFi space.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -13735,7 +13783,8 @@
       "extensions": {
         "link": "https://printer.finance/",
         "description": "Printer.finance is a community driven yield farming protocol. It allows PRINT tokenholders to stake liquidity tokens on printer.finance to earn PRINT. It implements a burn and a reduced token reward rate, aimed at curbing supply inflation and allowing tokens to preserve their long-term value.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -13774,7 +13823,8 @@
       "extensions": {
         "link": "https://dego.finance/",
         "description": "DEGO is a brand new idea towards a sustainable Decentralized Finance (DeFi) ecosystem.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -13814,7 +13864,8 @@
       "extensions": {
         "link": "https://moonyfi.network/",
         "description": "Utility staking token with a burn function.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -14152,7 +14203,8 @@
       "extensions": {
         "link": "https://shill.win/",
         "description": null,
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -14243,7 +14295,8 @@
       "extensions": {
         "link": "https://wenburn.com",
         "description": "\"THE WORLDS FIRST \r\n\r\n”Never before seen interplay of tokens.” \r\n\r\nSelf-Destructing   \r\nvs \r\nAuto-Minting\"",
-        "ogImage": "images/moonOnFire.jpg"
+        "ogImage": "images/moonOnFire.jpg",
+        "feeOnTransfer": true
       }
     },
     {
@@ -14269,7 +14322,8 @@
       "extensions": {
         "link": "https://rottenswap.org/#/",
         "description": "RottenSwap, a deflationary SushiSwap fork.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -14360,7 +14414,8 @@
       "extensions": {
         "link": "https://www.rarepepe.net/",
         "description": "Rare Pepe offers cryptic treasure hunts and much, much more.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -14737,7 +14792,8 @@
       "extensions": {
         "link": "https://cxn.network",
         "description": "CXN Network is a research-and-deploy start-up, which aims to build products around centralized and decentralized finance, at the core of deflationary tokenomics",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -14867,7 +14923,8 @@
       "extensions": {
         "link": "https://cvault.finance/",
         "description": "CORE is a non-inflationary cryptocurrency that is designed to execute profit-generating strategies autonomously with a completely decentralized approach. In existing autonomous strategy-executing platforms a team or single developer is solely responsible for determining how locked funds are used to generate ROI. This is hazardous to the health of the fund as it grows, as it creates flawed incentives, and invites mistakes to be made. CORE does away with this dynamic and instead opts for one with decentralized governance.\r\n\r\nCORE tokens holders will be able to provide strategy contracts and vote on what goes live and when, in order to decentralize autonomous strategy execution. 5% of all profits generated from these strategies are used to auto market-buy the CORE token.",
-        "ogImage": "/OGImage.png"
+        "ogImage": "/OGImage.png",
+        "feeOnTransfer": true
       }
     },
     {
@@ -15557,7 +15614,8 @@
       "extensions": {
         "link": "https://lync.network/",
         "description": "First of its kind DeFi cryptocurrency ecosystem designed to offer passive income token rewards powered NFT and board game dApps on the blockchain.",
-        "ogImage": "https://lync.network/wp-content/uploads/2020/11/meta_logo.png"
+        "ogImage": "https://lync.network/wp-content/uploads/2020/11/meta_logo.png",
+        "feeOnTransfer": true
       }
     },
     {
@@ -15726,7 +15784,8 @@
       "extensions": {
         "link": "https://heavensgate.finance/",
         "description": null,
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -16025,7 +16084,8 @@
       "extensions": {
         "link": "https://nobrainer.finance",
         "description": "Brain is an experimental protocol mashing up some of the most exciting innovations in DeFi and crypto collectibles.\r\nAdding features like the Deflationary Fee farming mechanics and combine it with NFT Farming.\r\nPut your $BRAIN to work by farming exclusive NFT arts. Stake LP tokens for access to our batch of legendary cards.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -16571,7 +16631,8 @@
       "extensions": {
         "link": "https://niceee.org",
         "description": "NICE is a SushiSwap fork with total supply pegged between 69 and 420.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -16792,7 +16853,8 @@
       "extensions": {
         "link": "https://vox.finance",
         "description": "Vox.Finance is an innovative DeFi project created by independent developers that seeks to revolutionize the market by providing a community-led approach.",
-        "ogImage": "/images/logoIcon.png"
+        "ogImage": "/images/logoIcon.png",
+        "feeOnTransfer": true
       }
     },
     {
@@ -16858,7 +16920,8 @@
       "extensions": {
         "link": "https://moondayfinance.com/",
         "description": "\"moonday.finance (MOONDAY) is a low supply deflationary token. there has only been 1969 ever created and 1% is burned per transaction. The theory is to create a token that deflates over time to test if deflationary tokens get value based upon burns over time. \r\n\r\n",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -16871,7 +16934,8 @@
       "extensions": {
         "link": "http://BooBanker.org",
         "description": "A Truly Deflationary Yield Farming with Dynamic Emissions and Burns.\r\n\r\nSustainable yield farming aiming to keep supply pegged at 50k.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -16910,7 +16974,8 @@
       "extensions": {
         "link": "https://yieldxfarming.io/",
         "description": null,
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -16923,7 +16988,8 @@
       "extensions": {
         "link": "https://pria.eth.link/",
         "description": "PRIA is a fully automated and decentralized digital asset that implements and manages a perpetual ultra-deflationary monetary policy favorable to inflation arbitrage by market participants.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -16949,7 +17015,8 @@
       "extensions": {
         "link": "https://bananodos.cc/",
         "description": "BananoDOS & yBAN is an experimental step into DeFi 2.0 (+ decentralized Staking, Farming, NFTs), combining the best of some of the most successful protocols, and going beyond.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -17249,7 +17316,8 @@
       "extensions": {
         "link": "https://socket.finance/#/",
         "description": "Socket Finance is an experiment in DeFi world. It is a suite of decentralized finance (DeFi) products focused on creating a simple way to generate returns for our users. Future projects will involve Vaults, Swap, NFT, etc.\r\n\r\nhttps://socket.finance/#/about",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -17405,7 +17473,8 @@
       "extensions": {
         "link": "https://surf.finance/",
         "description": "SURF.Finance is an innovative DeFi project focused on sustainability, transparency, and community. The project features a yield farming phase and a passive income machine that constantly rewards stakers.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -17457,7 +17526,8 @@
       "extensions": {
         "link": "https://chadswap.finance",
         "description": "STACY is the governance token for ChadSwap, a cross-chain smart AMM.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -17496,7 +17566,8 @@
       "extensions": {
         "link": "https://smplfoundation.com",
         "description": null,
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -17691,7 +17762,8 @@
       "extensions": {
         "link": "https://app.sergs.link",
         "description": "SERGS is an erc20 token that is a part of the SSL ecosystem. SERGS will be used to mint NFTs and a 2.5 % fee is collected on SERGS transactions which is rewarded to SSL holders ",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -18003,7 +18075,8 @@
       "extensions": {
         "link": "https://boobanker.org/#/",
         "description": null,
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -18042,7 +18115,8 @@
       "extensions": {
         "link": "https://wormhole.finance/",
         "description": "First DeFi \"Farm to Trade\" token. Every tx has a fee that is distributed to next 5 transactions. Buyers have more weightage. Sellers have less. Burns on each transactions also occur for those that don't farm.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -18120,7 +18194,8 @@
       "extensions": {
         "link": "https://drakoin.drakons.io",
         "description": "Drakoin, an ERC-20 token designed and developed with the main purpose as an in-app virtual currency inside Drakons, a Decentralized Application (DApp). Drakoin is a deflationary token with a variable burn and staking rate.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -18185,7 +18260,8 @@
       "extensions": {
         "link": "https://liquidefi.co/",
         "description": "Automated Liquidity Generating Operation (ALGO)",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -18263,7 +18339,8 @@
       "extensions": {
         "link": "https://volts.finance/",
         "description": "A deflationary yield farming protocol that marries being a store of value with promoting a vibrant community led ecosystem. We keep it simple and honest alongside aiming to be a guiding hand in allowing you guys to build on top of our work.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -18380,7 +18457,8 @@
       "extensions": {
         "link": "https://sav3.org",
         "description": "SAV3 is an experimental uncensorable platform with no CEO, no servers, and no content policy, with one objective: save the world. SAV3 is a DAO forked from Compound, all expenses and governance decisions are voted on by SAV3 holders (on chain whenever possible). 4% of all transfers are forever locked into liquidity, 4% are distributed to liquidity providers.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -18523,7 +18601,8 @@
       "extensions": {
         "link": "https://rootkit.finance",
         "description": "Rootkit is a highly advanced new DeFi protocol that pushes the limits of financial wizardry. Using a combination of permanent liquidity locks and a fixed supply currency, Rootkit creates a mathematical price floor. There can only ever be 10000 ROOT, and the price floor represents the lowest possible price a ROOT token can ever be. With our new ERC-31337 token wrapper, Rootkit is able to unlock the ETH from under the price floor and send it to a vault. This ETH is moved without effecting the market price, or depth of the order book. As the price floor rises through market volume, liquidity locks. Which means more ETH is unlocked from below the floor and sent to the vault. Because there is no tokens available to sell, the floor starts at the price, which is determined by how many ETH are raised in the ETH. Since we can unback the KETH below the floor, all of the ETH used to create the first liquidity can be used twice. This lets us offer our first LP a huge bonus, which is something n...",
-        "ogImage": "/images/hero.png"
+        "ogImage": "/images/hero.png",
+        "feeOnTransfer": true
       }
     },
     {
@@ -18549,7 +18628,8 @@
       "extensions": {
         "link": "https://nftobr.com",
         "description": "The 1st Role Playing (RP) NFT Cards on both Blockchains - #BSC & #ETH",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -18562,7 +18642,8 @@
       "extensions": {
         "link": "https://www.molten.finance",
         "description": "Molten (MOL) is a new fair-launch deflationary token that employs an auto-liquidity-pooling meta-market-making mechanism.",
-        "ogImage": "https://assets.website-files.com/5fb0f565336a7d11f72e058a/5fb47a0ec1fb5316475e4e6e_molte.jpg"
+        "ogImage": "https://assets.website-files.com/5fb0f565336a7d11f72e058a/5fb47a0ec1fb5316475e4e6e_molte.jpg",
+        "feeOnTransfer": true
       }
     },
     {
@@ -18627,7 +18708,8 @@
       "extensions": {
         "link": "https://cexlt.io/",
         "description": "Cexlt is dapp platform that bring decentralization and liquidity to centralized tokens.",
-        "ogImage": "https://cexlt.io/assets/images/clt-icon.png"
+        "ogImage": "https://cexlt.io/assets/images/clt-icon.png",
+        "feeOnTransfer": true
       }
     },
     {
@@ -18692,7 +18774,8 @@
       "extensions": {
         "link": null,
         "description": "DeFi token with a progressive deflation mechanism.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -18796,7 +18879,8 @@
       "extensions": {
         "link": "https://reflect.finance",
         "description": "RFI works by applying a 1% fee to each transaction and instantly splitting that fee among all holders of the token.\r\n",
-        "ogImage": "https://raw.githubusercontent.com/reflectfinance/reflect-media/main/reflect-meta.png"
+        "ogImage": "https://raw.githubusercontent.com/reflectfinance/reflect-media/main/reflect-meta.png",
+        "feeOnTransfer": true
       }
     },
     {
@@ -18809,7 +18893,8 @@
       "extensions": {
         "link": "https://ethereumyield.farm/",
         "description": "Users are incentivised to stake Uniswap liquidity provider tokens. Fees from these tokens are farmed. A percentage of these fees goes toward the autonomous strategies like liquidating LP tokens, and performing an (`ETH-ETHY`) buy back (increasing the price). Any purchased ETHY tokens will be distributed to stakers/farmers\r\n\r\nETHY implements a strong deflationary force on each token. Every time an ETHY token is transferred, a small fee is taken, which is returned to the farmers. This mechanism incentivises holding and farming.\r\n\r\nETHY holders will be able to vote on proposals– so long as they have staked liquidity in the pools. The community will decide everything from developer fees and site design to the exact farming options available.",
-        "ogImage": "/screenshot.png"
+        "ogImage": "/screenshot.png",
+        "feeOnTransfer": true
       }
     },
     {
@@ -18835,7 +18920,8 @@
       "extensions": {
         "link": "https://hype-finance.com/",
         "description": "Hype Finance is a fully decentralized gambling and Defi ecosystem where token holders receive profits from the Casino.  An innovative approach to online gambling where your tokens allow you to participate in the rewards.",
-        "ogImage": "https://hype-finance.com/wp-content/uploads/2020/12/AdobeStock_381097571-scaled.jpeg"
+        "ogImage": "https://hype-finance.com/wp-content/uploads/2020/12/AdobeStock_381097571-scaled.jpeg",
+        "feeOnTransfer": true
       }
     },
     {
@@ -18913,7 +18999,8 @@
       "extensions": {
         "link": "https://www.prophet.finance/",
         "description": "Fluid and scalable yield-generation with adjustable rates governed by the community",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -18939,7 +19026,8 @@
       "extensions": {
         "link": "https://holdtowin.eth.link/",
         "description": null,
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -18952,7 +19040,8 @@
       "extensions": {
         "link": "https://www.ethanoltoken.com/",
         "description": "ERC-20 That gives cash back rewards for gas fees, up to 100%! ",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -19030,7 +19119,8 @@
       "extensions": {
         "link": "https://vanilla.network/",
         "description": "The Vanilla Network is a deflationary ERC-20 token with decentralized finance at the heart of its ecosystem driven by Blockchain technology. The premise of this project is to produce award winning staking and betting decentralized applications (dApps) that appeal to all betting enthusiasts and those seeking rewards for long-term participation.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -19344,7 +19434,8 @@
       "extensions": {
         "link": "https://stvke.app/",
         "description": "Create your own ERC-20 tokens on https://stvke.app and manage them on https://stvke.info.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -19435,7 +19526,8 @@
       "extensions": {
         "link": "https://bbra.io/#/",
         "description": "The premier DeFi, yield-farming DAO protocol that incentives its community to build and take part in the next crypto revolution.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -19448,7 +19540,8 @@
       "extensions": {
         "link": "https://www.adventuretoken.com/",
         "description": "WHAT IS ADVENTURE TOKEN?\r\nTWA Adventure Token is a deflationary community token. \r\n\r\nEvery time Adventure Token is purchased, sold or transferred between wallets one percent of the total transaction value is burnt, meaning that with every trade Adventure Token becomes scarcer. Trading attracts liquidity, which in-turn attracts further trading. Liquidity grows and the supply of Adventure Token decreases with every trade.\r\n\r\nHolding Adventure Token also gives you the opportunity to earn further rewards in the Adventure Luna Fund.",
-        "ogImage": "https://www.adventuretoken.com/images/TWA-Share-image.png"
+        "ogImage": "https://www.adventuretoken.com/images/TWA-Share-image.png",
+        "feeOnTransfer": true
       }
     },
     {
@@ -19526,7 +19619,8 @@
       "extensions": {
         "link": "https://www.hype-finance.com/",
         "description": null,
-        "ogImage": "https://hype-finance.com/wp-content/uploads/2020/12/AdobeStock_381097571-scaled.jpeg"
+        "ogImage": "https://hype-finance.com/wp-content/uploads/2020/12/AdobeStock_381097571-scaled.jpeg",
+        "feeOnTransfer": true
       }
     },
     {
@@ -19539,7 +19633,8 @@
       "extensions": {
         "link": "https://iterationsyndicate.com/#/",
         "description": "Governance for Renascent ecosystem",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -19695,7 +19790,8 @@
       "extensions": {
         "link": "https://wav3.org/",
         "description": "Waves are caused by energy passing through the water, causing the water to move in a circular motion. Water molecules involved in wave motion only rotate in place and have little translational motion in the direction of wave propagation, but have a huge amount of energy propagated along the waves.\r\n\r\nSimilar to water molecules — WAV3 join to the highly volatile Cryptocurrency market, it is not affected by a special deflation mechanism, but is a higher yield.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -19747,7 +19843,8 @@
       "extensions": {
         "link": "https://ethereumstake.farm",
         "description": null,
-        "ogImage": "/screenshot.png"
+        "ogImage": "/screenshot.png",
+        "feeOnTransfer": true
       }
     },
     {
@@ -19825,7 +19922,8 @@
       "extensions": {
         "link": "https://stargazeprotocol.com/",
         "description": "Stargaze Protocol (STGZ), A Fair Launch Project With Automatic Fee Distribution and Staking",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -19877,7 +19975,8 @@
       "extensions": {
         "link": "https://www.rbase.finance/",
         "description": null,
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -19994,7 +20093,8 @@
       "extensions": {
         "link": "https://xvix.finance/",
         "description": "XVIX is a token that absorbs value from volatility, it is the first token to make use of non-uniform rebasing to incentivise liquidity provision without creating sell pressure",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -20046,7 +20146,8 @@
       "extensions": {
         "link": "https://deflectprotocol.io",
         "description": "DeFi Hybrid of Frictionless earning, Staking Pools, Locked Liquidity, Supply Burn and Boosts",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -20085,7 +20186,8 @@
       "extensions": {
         "link": "https://rizencoin.com",
         "description": "First experimental community driven defi project with POL + POT + POS concept. Rizen gives you lifetime passive reward. The more transactions happen the more reward you will get from staking. Also, There is 1% weekly holding reward.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -20215,7 +20317,8 @@
       "extensions": {
         "link": "https://n3rd.finance",
         "description": null,
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -20228,7 +20331,8 @@
       "extensions": {
         "link": "https://www.blazenetwork.online/blazegoingdefi",
         "description": null,
-        "ogImage": "https://static.wixstatic.com/media/7e167b_7c861f467aee4f8bbdadff86e63a34fe~mv2.png/v1/fill/w_512,h_512,al_c/7e167b_7c861f467aee4f8bbdadff86e63a34fe~mv2.png"
+        "ogImage": "https://static.wixstatic.com/media/7e167b_7c861f467aee4f8bbdadff86e63a34fe~mv2.png/v1/fill/w_512,h_512,al_c/7e167b_7c861f467aee4f8bbdadff86e63a34fe~mv2.png",
+        "feeOnTransfer": true
       }
     },
     {
@@ -20241,7 +20345,8 @@
       "extensions": {
         "link": "https://r34p.finance/",
         "description": "R34P  (R34P) is a soft fork and constructed as a secondary layer on Reflect Finance (RFI) project. R34P (R34P) token benefits every holder with a low-cost charge of 1% fee in every transaction on the blockchain, redistributes to every wallet holder automatically based on the amount of R34P token in their wallets and another 1% will be sent to 0x000 wallet that will automatically burn, reducing the circulating/ total supply.  ",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -20307,7 +20412,8 @@
       "extensions": {
         "link": "https://reflector.finance/",
         "description": "Reflector is a modified fork of RFI(reflect.finance) with a 12% transaction fee",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -20346,7 +20452,8 @@
       "extensions": {
         "link": "https://absorber.finance",
         "description": "A protocol with contract-owned liquidity and passive yield farming that's self-sustaining as well as deflationary",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -20385,7 +20492,8 @@
       "extensions": {
         "link": "https://tornado.finance/",
         "description": "Tornado is a decentralized finance protocol forked from CORE backed by a deflationary token with a governance feature. TCORE is the token that users can use to yield farm and stake.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -20424,7 +20532,8 @@
       "extensions": {
         "link": "https://dragonflyprotocol.com",
         "description": "Yield Farming Through Holding with Added Vaults",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -20463,7 +20572,8 @@
       "extensions": {
         "link": "https://bananacoin.finance/",
         "description": "Bananacoin is a groundbreaking decentralized and community-powered cryptocurrency that can be used for digital services.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -20645,7 +20755,8 @@
       "extensions": {
         "link": "https://tartarus-group.com",
         "description": "The central token of the Tartarus Network, bridging liquidity everywhere, always.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -20750,7 +20861,8 @@
       "extensions": {
         "link": "https://aqua.coilcrypto.com",
         "description": "Deflationary asset that rewards holders fees every transaction",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -20815,7 +20927,8 @@
       "extensions": {
         "link": "https://dripper.finance",
         "description": "$DRIP is a radical economic experiment that taxes sell-side transactions. It is gas-optimized & efficient, employing new methods to generate volume.",
-        "ogImage": "https://dripper.finance/dripperlogo.png"
+        "ogImage": "https://dripper.finance/dripperlogo.png",
+        "feeOnTransfer": true
       }
     },
     {
@@ -20842,7 +20955,8 @@
       "extensions": {
         "link": "https://yvs.finance/",
         "description": "The first and only yield-farming, vaults and staking deflationary token with no admin control.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -20907,7 +21021,8 @@
       "extensions": {
         "link": "https://vaultz.info",
         "description": "Vaultz(VAULTZ) is an Autonomous Yield and Liquidity Generation Protocol.",
-        "ogImage": "https://jimdo-storage.freetls.fastly.net/image/162569041/d1ec92d8-e0e0-4bfb-b680-7d92066f97f9.jpg?format=pjpg&quality=80&auto=webp&disable=upscale&width=1200&height=630&crop=1:0.525"
+        "ogImage": "https://jimdo-storage.freetls.fastly.net/image/162569041/d1ec92d8-e0e0-4bfb-b680-7d92066f97f9.jpg?format=pjpg&quality=80&auto=webp&disable=upscale&width=1200&height=630&crop=1:0.525",
+        "feeOnTransfer": true
       }
     },
     {
@@ -20972,7 +21087,8 @@
       "extensions": {
         "link": "https://linkbased.org",
         "description": "LinkBased (LBD), is an experimental protocol with the token pegged to the total market cap of Chainlink, and a 3% tax on transfers paid to liquidity providers.",
-        "ogImage": "https://ibb.co/pLGffMR"
+        "ogImage": "https://ibb.co/pLGffMR",
+        "feeOnTransfer": true
       }
     },
     {
@@ -20985,7 +21101,8 @@
       "extensions": {
         "link": "https://3x.exchange/",
         "description": "3x.exchange is the first complete decentralized non-custodial leveraged tokens exchange built on ethereum powered by chainlink price oracle.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -21193,7 +21310,8 @@
       "extensions": {
         "link": "https://www.nirvanadefi.com",
         "description": "An Autonomous Yield and Liquidity Generation Protocol",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -21232,7 +21350,8 @@
       "extensions": {
         "link": "https://polkainsure.finance/",
         "description": "PolkaInsure is a decentralized P2P insurance marketplace on Polkadot Ecosystem powered by Polkadot Ecosystem.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -21454,7 +21573,8 @@
       "extensions": {
         "link": "https://zzz.finance/",
         "description": null,
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -21545,7 +21665,8 @@
       "extensions": {
         "link": "https://tunnelprotocol.io/",
         "description": "Tunnel the liquidity protocol connecting DeFi projects.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -21571,7 +21692,8 @@
       "extensions": {
         "link": "https://eternalcash.online/",
         "description": "Eternal Cash $EC is our storage of value and utility token for our Casino and future dApps.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -21714,7 +21836,8 @@
       "extensions": {
         "link": "https://fission.cash/",
         "description": "CX is a hyper-deflationary self-governing ERC20 token with inbuilt mechanisms\r\nto automatically burn 4% of the total supply and apply a 5% tax upon each transaction.\r\n\r\nThe inbuilt burn mechanism provides an immediate deflation of 4% each time the token is swapped or transferred causing the value of FCX to increase over time autonomously. Additionally, the 5% tax applied to each transaction is redistributed amongst holders of the token and provides an automatic yield generation without requiring any gas fees for the balance to be updated in token holders’ wallets.\r\n\r\nUltimately, FCX builds on and improves the RFI framework by increasing the tax (and therefore the reward to holders) by a factor of 5, whilst also providing a 4% deflationary burn mechanic of which RFI lacks.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -21740,7 +21863,8 @@
       "extensions": {
         "link": "https://www.niftygotchi.com",
         "description": "Currency coin for the NiFTygotchi universe",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -22129,7 +22253,8 @@
       "extensions": {
         "link": "https://passive-income.io",
         "description": "PSI is an innovative Ethereum token that re-imagines the concept of DeFI yield generation and change this to DeFi Passive Income generation.\r\n\r\nThere is no institution or centralized party that shares the fees with PSI. There is no interface needed to receive the fees. No action needs to be taken on the part of the holder other than to hold PSI in a wallet they control. With PSI, there are no vaults that could be hacked and drained or treasury funds that could be messed up. There is only the free market.\r\n\r\nAt its core, PSI charges a 1% transaction fee and re-distributes that fee to existing PSI holders instantly and automatically at the time of each transaction.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -22272,7 +22397,8 @@
       "extensions": {
         "link": "https://soar.fi",
         "description": "SOAR is an ERC-20 with a frictionless yield generator mechanism that applies a 1% fee on every transfer and instantly distributes the fee among holders. This is the easiest form of staking that exists today. Holders do not need to deposit tokens anywhere and wait for fees to be delivered. Fees are awarded by the smart contract and automatically reflected in the holder’s balance. There is no inflation in SOAR, as the same tokens are redistributed among holders based on transaction volume. ",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -22389,7 +22515,8 @@
       "extensions": {
         "link": "https://unidexgas.com/",
         "description": "\"The benefits of this token can allow users to trade on decentralized exchanges in the ethereum network without worrying too much about gas\r\nfees because of the cashbacks UNDG token provides. The formulas and mathematical calculations developed for this token allows it to be sustainable in time and to become the most trustworthy and useful utility token when it comes to saving from the increasing ethereum gas fees. 100% Cashbacks on ETH gas spent.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -22415,7 +22542,8 @@
       "extensions": {
         "link": "https://polkabridge.org/",
         "description": "\"PolkaBridge is a decentralized all-in-one application platform.\r\nOne of PolkaBridge’s most noticeable product is PolkaBridge DEX - a decentralized exchange that allows users to swap tokens on Polkadot to other ones on other blockchain platforms without any centralized organizations. In addition, with the smart deflationary farming mechanism, liquidity providers can earn more rewards than they think.\r\nIn future, we will launch Lending, Launchpad, Predict and more to scale up ecosystem.\"",
-        "ogImage": "https://polkabridge.org/assets/img/symbol.png"
+        "ogImage": "https://polkabridge.org/assets/img/symbol.png",
+        "feeOnTransfer": true
       }
     },
     {
@@ -22454,7 +22582,8 @@
       "extensions": {
         "link": "https://www.darkbundles.finance/",
         "description": "Prediction based Staking platform with rewards from transaction fess",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -22467,7 +22596,8 @@
       "extensions": {
         "link": "https://bitbotprotocol.tech/",
         "description": "Stake tokens to use trading bots.",
-        "ogImage": "https://bitbotprotocol.tech/wp-content/uploads/2021/01/cropped-Untitled-design-2021-01-16T133356.362.png"
+        "ogImage": "https://bitbotprotocol.tech/wp-content/uploads/2021/01/cropped-Untitled-design-2021-01-16T133356.362.png",
+        "feeOnTransfer": true
       }
     },
     {
@@ -22558,7 +22688,8 @@
       "extensions": {
         "link": "https://nirvanadefi.com",
         "description": "Bliss is the second token issued from the Nirvana Defi ecosystem, with Bliss you are able to stake and earn WBTC rewards. ",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {
@@ -22571,7 +22702,8 @@
       "extensions": {
         "link": "https://interop.finance/",
         "description": "You’re looking at the newest community driven go- to platform for everything NFT and more. Watch and join the show, be a player or be a spectator in our world with many highs & challenges.",
-        "ogImage": null
+        "ogImage": null,
+        "feeOnTransfer": true
       }
     },
     {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "sync-external": "tsx tools/sync-external.ts",
     "update-featured": "tsx tools/update-featured.ts",
     "sync-coingecko": "tsx tools/sync-coingecko.ts",
+    "sync-fee-on-transfer": "tsx tools/sync-fee-on-transfer.ts",
     "format": "prettier --write .",
     "prepare": "husky"
   },

--- a/tools/sync-fee-on-transfer.ts
+++ b/tools/sync-fee-on-transfer.ts
@@ -1,0 +1,305 @@
+import path from 'node:path'
+import { promises as fs } from 'node:fs'
+import { parseArgs } from 'node:util'
+
+const TOKEN_DIRECTORY_ROOT = path.resolve('./index')
+
+const GOPLUS_API_BASE = 'https://api.gopluslabs.io/api/v1/token_security'
+
+// GoPlus computes a fresh report only for single-address requests; multi-address
+// requests return just the entries it already has cached. Requests are therefore
+// serial. Spacing keeps most requests under the unauthenticated limit; the limit is
+// not a fixed window, so occasional rate-limit responses are expected and retried.
+const REQUEST_DELAY_MS = 4000
+const MAX_BACKOFF_MS = 60000
+const RATE_LIMITED_CODE = 4029
+
+// Cached responses keyed `chainId:address`, so an interrupted scan resumes without
+// re-querying. Transfer semantics do not change for a non-upgradeable token.
+const CACHE_PATH = path.resolve('./tools/.fee-on-transfer-cache.json')
+
+// Chain folder name -> chainId, limited to chains GoPlus covers
+// (https://api.gopluslabs.io/api/v1/supported_chains).
+const CHAIN_IDS: Record<string, number> = {
+  mainnet: 1,
+  polygon: 137,
+  base: 8453,
+  optimism: 10,
+  arbitrum: 42161,
+  avalanche: 43114,
+  bnb: 56,
+  gnosis: 100,
+  berachain: 80094,
+  soneium: 1868,
+  sonic: 146,
+  monad: 143,
+}
+
+const NATIVE_ADDRESSES = new Set([
+  '0x0000000000000000000000000000000000000000',
+  '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+])
+
+type TokenListEntry = {
+  chainId: number
+  address: string
+  name: string
+  symbol?: string
+  decimals?: number
+  logoURI?: string
+  extensions?: Record<string, unknown>
+}
+
+type TokenList = {
+  tokens: TokenListEntry[]
+}
+
+type TokenSecurity = {
+  token_symbol?: string
+  transfer_tax?: string
+  buy_tax?: string
+  sell_tax?: string
+}
+
+type TokenSecurityResponse = {
+  code: number
+  message?: string
+  result?: Record<string, TokenSecurity>
+}
+
+type CacheEntry = { transferTax: number | null }
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+/**
+ * A tax rate is only meaningful when GoPlus returns a parseable number. An empty
+ * string means it did not compute one, which is not the same as zero.
+ */
+function parseTaxRate(rate: string | undefined): number | null {
+  if (rate == null || rate.trim() === '') return null
+  const parsed = Number(rate)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+async function fetchTokenSecurity(
+  chainId: number,
+  address: string,
+  maxRetries = 6
+): Promise<TokenSecurity> {
+  const url = `${GOPLUS_API_BASE}/${chainId}?contract_addresses=${address}`
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    let response: Response
+    try {
+      response = await fetch(url)
+    } catch (error) {
+      // Transient DNS/socket failures must not end a scan of thousands of tokens.
+      if (attempt === maxRetries) throw error
+      const backoff = Math.min(2 ** (attempt + 1) * 5000, MAX_BACKOFF_MS)
+      console.warn(`  Request failed, retrying in ${backoff}ms...`)
+      await sleep(backoff)
+      continue
+    }
+
+    if (!response.ok) {
+      // 5xx is the upstream or its CDN failing, not a bad request; retry it.
+      if (response.status >= 500 && attempt < maxRetries) {
+        const backoff = Math.min(2 ** (attempt + 1) * 5000, MAX_BACKOFF_MS)
+        console.warn(`  HTTP ${response.status}, retrying in ${backoff}ms...`)
+        await sleep(backoff)
+        continue
+      }
+      throw new Error(
+        `GoPlus returned HTTP ${response.status} for ${chainId}:${address}`
+      )
+    }
+
+    let body: TokenSecurityResponse
+    try {
+      body = (await response.json()) as TokenSecurityResponse
+    } catch (error) {
+      // A CDN error page parses as neither JSON nor a useful result.
+      if (attempt === maxRetries) throw error
+      const backoff = Math.min(2 ** (attempt + 1) * 5000, MAX_BACKOFF_MS)
+      console.warn(`  Malformed response, retrying in ${backoff}ms...`)
+      await sleep(backoff)
+      continue
+    }
+
+    if (body.code === RATE_LIMITED_CODE && attempt < maxRetries) {
+      const backoff = Math.min(2 ** (attempt + 1) * 5000, MAX_BACKOFF_MS)
+      console.warn(`  Rate limited, retrying in ${backoff}ms...`)
+      await sleep(backoff)
+      continue
+    }
+
+    if (body.code === RATE_LIMITED_CODE) {
+      throw new Error(
+        `GoPlus rate limit not cleared after ${maxRetries} retries for ${chainId}:${address}`
+      )
+    }
+
+    return body.result?.[address.toLowerCase()] ?? {}
+  }
+
+  throw new Error(`GoPlus request loop exhausted for ${chainId}:${address}`)
+}
+
+async function loadCache(): Promise<Record<string, CacheEntry>> {
+  let raw: string
+  try {
+    raw = await fs.readFile(CACHE_PATH, 'utf-8')
+  } catch {
+    return {}
+  }
+
+  // A corrupt cache means silently rescanning everything, so surface it instead.
+  try {
+    return JSON.parse(raw) as Record<string, CacheEntry>
+  } catch {
+    throw new Error(
+      `Cache at ${CACHE_PATH} is unreadable; delete it to rescan from scratch.`
+    )
+  }
+}
+
+async function saveCache(cache: Record<string, CacheEntry>): Promise<void> {
+  // Written after every lookup, so a kill mid-write must not truncate the file.
+  const tmp = `${CACHE_PATH}.tmp`
+  await fs.writeFile(tmp, `${JSON.stringify(cache, null, 2)}\n`)
+  await fs.rename(tmp, CACHE_PATH)
+}
+
+async function processChain(
+  chain: string,
+  write: boolean,
+  cache: Record<string, CacheEntry>
+): Promise<{ flagged: number; scanned: number; unknown: number }> {
+  const chainId = CHAIN_IDS[chain]
+  const tokenListPath = path.join(TOKEN_DIRECTORY_ROOT, chain, 'erc20.json')
+
+  let tokenList: TokenList
+  try {
+    tokenList = JSON.parse(
+      await fs.readFile(tokenListPath, 'utf-8')
+    ) as TokenList
+  } catch {
+    console.warn(`[${chain}] No erc20.json found, skipping.`)
+    return { flagged: 0, scanned: 0, unknown: 0 }
+  }
+
+  const candidates = tokenList.tokens.filter(
+    token => !NATIVE_ADDRESSES.has(token.address.toLowerCase())
+  )
+
+  console.log(
+    `[${chain}] Scanning ${candidates.length} tokens (~${Math.ceil(
+      (candidates.length * REQUEST_DELAY_MS) / 60000
+    )} min)...`
+  )
+
+  let flagged = 0
+  let unknown = 0
+
+  for (let i = 0; i < candidates.length; i++) {
+    const token = candidates[i]
+    const cacheKey = `${chainId}:${token.address.toLowerCase()}`
+
+    let transferTax: number | null
+    if (cacheKey in cache) {
+      transferTax = cache[cacheKey].transferTax
+    } else {
+      const security = await fetchTokenSecurity(chainId, token.address)
+      transferTax = parseTaxRate(security.transfer_tax)
+      cache[cacheKey] = { transferTax }
+      await saveCache(cache)
+      if (i < candidates.length - 1) await sleep(REQUEST_DELAY_MS)
+    }
+
+    if (transferTax == null) {
+      unknown++
+      continue
+    }
+    if (transferTax === 0) continue
+
+    flagged++
+    console.log(
+      `  [${chain}] ${token.symbol ?? token.name} (${token.address}) transfer_tax=${transferTax}`
+    )
+
+    token.extensions = { ...token.extensions, feeOnTransfer: true }
+  }
+
+  console.log(
+    `[${chain}] ${write ? 'Flagged' : 'Would flag'} ${flagged} tokens` +
+      ` (${unknown} without a transfer tax result).`
+  )
+
+  if (flagged > 0 && write) {
+    await fs.writeFile(tokenListPath, `${JSON.stringify(tokenList, null, 2)}\n`)
+    console.log(`[${chain}] Wrote ${tokenListPath}`)
+  }
+
+  return { flagged, scanned: candidates.length, unknown }
+}
+
+const main = async () => {
+  const args = process.argv.slice(2).filter(a => a !== '--')
+  const { values } = parseArgs({
+    args,
+    options: {
+      write: { type: 'boolean', default: false },
+      chain: { type: 'string' },
+    },
+    strict: true,
+  })
+
+  const write = values.write ?? false
+  const chainFilter = values.chain
+
+  if (chainFilter && !CHAIN_IDS[chainFilter]) {
+    console.error(
+      `Unknown chain "${chainFilter}". Supported: ${Object.keys(CHAIN_IDS).join(', ')}`
+    )
+    process.exitCode = 1
+    return
+  }
+
+  const chains = chainFilter ? [chainFilter] : Object.keys(CHAIN_IDS)
+
+  const cache = await loadCache()
+
+  let flagged = 0
+  let scanned = 0
+  let unknown = 0
+  const failed: string[] = []
+  for (const chain of chains) {
+    try {
+      const result = await processChain(chain, write, cache)
+      flagged += result.flagged
+      scanned += result.scanned
+      unknown += result.unknown
+    } catch (error) {
+      // One chain failing must not discard the chains after it; the cache keeps
+      // completed lookups so a rerun resumes cheaply.
+      failed.push(chain)
+      console.error(`[${chain}] Failed: ${(error as Error).message}`)
+    }
+  }
+
+  console.log(
+    `\nScanned ${scanned} tokens, flagged ${flagged}, ${unknown} without a transfer tax result.`
+  )
+  if (failed.length > 0) {
+    console.error(`Incomplete for: ${failed.join(', ')} — rerun to finish.`)
+    process.exitCode = 1
+  }
+  if (!write) {
+    console.log('Dry run — pass --write to apply changes.')
+  }
+}
+
+main().catch(error => {
+  console.error('Failed to sync fee-on-transfer flags:', error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
## What

Adds `extensions.feeOnTransfer: true` to 132 mainnet ERC-20s, plus `tools/sync-fee-on-transfer.ts` to refresh the flag.

Fee-on-transfer tokens (transfer taxes, reflection, burn-on-transfer) credit the recipient less than the sender sends. Any integration that assumes `transfer(x)` delivers `x` breaks on them — the recipient balance can never reach the expected amount, so balance-based preconditions are unsatisfiable by construction and no amount the user sends will fix it.

Example: SHUF (`0x3a9fff45…6b9e`) burns 1% and redistributes 1% on every transfer. A send of 1237.674738 credits 1212.921243240.

## Data source

GoPlus token security API (`transfer_tax != 0`), free unauthenticated tier. New third-party dependency for this repo — previously only CoinGecko was used. CoinGecko was checked first and publishes nothing equivalent: no tax, honeypot or transfer-behaviour field on any endpoint. The only signals in this repo today are free-text `description` prose, which is not machine-actionable.

Coverage is mainnet-only in practice:

| chain | scanned | flagged | no data |
|---|---|---|---|
| mainnet | 1987 | 132 | 286 |
| polygon | 411 | 0 | 230 |
| base | 99 | 0 | 25 |
| optimism | 77 | 0 | 77 |
| arbitrum | 75 | 0 | 32 |
| avalanche | 34 | 0 | 34 |
| bnb | 28 | 0 | 8 |
| gnosis | 12 | 0 | 12 |
| berachain / soneium / sonic / monad | 15 | 0 | 13 |

**717 of 2738 scanned (26%) returned no tax data.** Outside mainnet, "0 flagged" mostly means "GoPlus has no data", not "clean" — optimism is 77/77 unknown, avalanche 34/34, gnosis 12/12. An empty `transfer_tax` is treated as unknown, not as zero, and such tokens are left unflagged.

## Verification

The GoPlus results were independently double-checked against on-chain state for **all 132 flagged tokens**, using a separate script (deliberately **not committed** — it is a one-off audit, not something to maintain). Method: `eth_simulateV1`, transfer from a token's Uniswap V2 pair to a fresh address, diff recipient balance before/after in the same simulated block.

Outcome:

- **114 confirmed directly** — measured tax matched GoPlus.
- **16 initially read as 0%**, all traced to the tokens exempting the Uniswap pair from their fee. Re-measured with an ordinary holder→holder transfer, they charge the full rate and match GoPlus: CHADS 49.9999% (claimed 50%), TCORE 23.9999% (24%), PAMP 7.9999% (8%). These were a flaw in the audit method, not bad flags.
- **2 unverifiable**: `DGX` (V2 pair holds 3 base units, too small to probe) and `TNI` (non-standard ERC-20, `transfer` returns no data). Neither is contradicted; both keep the flag. Unverifiable is not treated as clean.

Net: **130/132 confirmed on-chain, 0 genuine contradictions.**

One correction to GoPlus surfaced: `XVIX` reports 0.5% but measures 0.6987%. The flag is still correct. Since exact rates can be wrong, `feeOnTransfer` is stored as a boolean only — no rate is persisted.

## Tool

`pnpm sync-fee-on-transfer` — dry-run by default, `--write` applies, `--chain <name>` scopes. Follows the existing `sync-coingecko.ts` conventions.

Notes for anyone re-running it:
- Requests are serial. GoPlus only computes a fresh report for single-address requests; multi-address requests return only what it already has cached (30 addresses returned 0 results).
- The free tier rate-limits aggressively under sustained load. A full scan takes ~4h. Results are cached to a gitignored file, so an interrupted run resumes for free.
- Rate limits, 5xx, malformed bodies and transient DNS/socket failures are retried with bounded backoff. An exhausted retry throws rather than silently recording "no tax" — a false negative here would strand funds.

## Scope

Data + tooling only. Consumers do not read this field yet. `go-tokendirectory`'s `ContractInfoExtension` needs a matching `FeeOnTransfer bool` before anything downstream can act on it.
