### PR TITLE
chore: flag fee-on-transfer tokens beyond mainnet

### DIFF
--- a/index/bnb/erc20.json
+++ b/index/bnb/erc20.json
@@ -637,6 +637,23 @@
         },
         "protocol": "aave"
       }
+    },
+    {
+      "chainId": 56,
+      "address": "0x5cA42204cDAa70d5c773946e69dE942b85CA6706",
+      "name": "Position Token",
+      "symbol": "POSI",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/17459/large/posi.png?1696517002",
+      "extensions": {
+        "link": "https://position.exchange/",
+        "description": "Position Exchange is a decentralized trading protocol on BNB Chain offering perpetual futures, staking and yield products. POSI is its governance and utility token.",
+        "categories": ["defi", "governance", "staking"],
+        "ogImage": null,
+        "originChainId": 56,
+        "originAddress": null,
+        "feeOnTransfer": true
+      }
     }
   ],
   "version": {

--- a/index/index.json
+++ b/index/index.json
@@ -132,7 +132,7 @@
       "chainId": 56,
       "tokenLists": {
         "erc1155.json": "ae7818922dbfa44cc008d2a1efc4bf0a6545f92c66fe2ee2596d75be78892bc6",
-        "erc20.json": "a012f8c60aa01d9b05386beeb1789f0b064d7dcfb11a7e5ffedee411e0401acc",
+        "erc20.json": "ecd4410d45eb6ab2c3a1fd52df0de9581d8b9d39d8752db226b34900e1eb624a",
         "erc721.json": "e5471df6794131d1eb8a2a03a5984052a87015b5c1b204eb98762b492ecac91e",
         "misc.json": "bf2fb3b03bd2fdda14b8b13075d0e4bbe3eef0daf4bf83f1a6125d9939cf4e86"
       }
@@ -250,7 +250,7 @@
       "chainId": 137,
       "tokenLists": {
         "erc1155.json": "f6a710897facb2b4caa28a78694166302811cbd31139d04cccdc4a3e4a18a36c",
-        "erc20.json": "d14965f7db29337b7309ebe26db10beefdfa46873f15633d4eaa9e6e7dc75a91",
+        "erc20.json": "b771139705041ecab22d1af557d3e52ab4c2c30d0782db7011506c2103116e45",
         "erc721.json": "e32b38f33246eb5dc67bacbb7d72ac0612060cc20aed7d628c30320708fff62f",
         "misc.json": "80ed5add20b07abafcd9ced20d8cdc0ba6a588b724320c66739e1db3d264d503"
       }

--- a/index/polygon/erc20.json
+++ b/index/polygon/erc20.json
@@ -2311,7 +2311,8 @@
         "categories": ["gaming", "casino"],
         "ogImage": null,
         "originChainId": 1,
-        "originAddress": "0x1f6deadcb526c4710cf941872b86dcdfbbbd9211"
+        "originAddress": "0x1f6deadcb526c4710cf941872b86dcdfbbbd9211",
+        "feeOnTransfer": true
       }
     },
     {


### PR DESCRIPTION
Follow-up to #153, which flagged fee-on-transfer tokens on mainnet only. This
covers the remaining chains GoPlus supports that have a curated list.

Scanned with `pnpm sync-fee-on-transfer --chain <c> --write` — no tool changes;
its `CHAIN_IDS` already covered every eligible chain, #153 just did not run them.

| chain | scanned | flagged | no transfer-tax result |
|---|---|---|---|
| polygon | 411 | 1 | 231 |
| base | 99 | 0 | 28 |
| optimism | 77 | 0 | 77 |
| arbitrum | 75 | 0 | 32 |
| avalanche | 34 | 0 | 34 |
| bnb | 29 | 1 | 9 |
| gnosis | 12 | 0 | 12 |
| berachain | 5 | 0 | 5 |
| soneium | 4 | 0 | 4 |
| sonic | 4 | 0 | 4 |
| monad | 2 | 0 | 0 |

**Flagged**

- **RTK** (Ruletka) `0x38332d8671961ae13d0bde040d536eb336495eea` on polygon —
  `transfer_tax=1`. Its own description states a "1 in 6 chance burn mechanism".
- **POSI** (Position Token) `0x5cA42204cDAa70d5c773946e69dE942b85CA6706` on bnb —
  `transfer_tax=0.01`.

**New entry: POSI**

POSI was not in `index/bnb/erc20.json` at all, so there was no entry to
annotate. It is added here and then flagged by the tool from live GoPlus data.
Metadata is verified on-chain (`name`, `symbol`, `decimals` via `eth_call`);
logo from CoinGecko, link from the project site.

A POSI transfer taxed 1% of a user's deposit below the amount a Trails route
had signed for, leaving the funds stranded in an intent wallet. Trails rejects
quotes for tokens carrying this flag.

**Note on the empty results**

436 of 752 tokens returned no transfer-tax result from GoPlus. The flag is a
positive assertion — unflagged means no transfer tax is known, not that none
exists — so those are left untouched.

**Chains not covered**

Every remaining directory list is either a testnet or a chain absent from
GoPlus's supported set (katana, hyperevm, apechain, polygon-zkevm, somnia,
etherlink, skale, homeverse, incentiv, arbitrum-nova, astar). The external
lists under `index/_external/` are also unflagged: `sync-external.ts` clears
and rewrites that directory verbatim on each run, so a flag written there
would not survive. Worth a separate change if those need covering.

`pnpm reindex` re-run after formatting; the `index.json` diff is the two
regenerated list hashes.